### PR TITLE
Add minimal GPIO-backed register MVP

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,12 @@
+{
+  "name": "register_mvp",
+  "build": {
+    "dockerfile": "../Dockerfile",
+    "context": ".."
+  },
+  "runArgs": [
+    "--device=/dev/gpiochip0"
+  ],
+  "postCreateCommand": "cmake -S . -B build -DUSE_MOCK_GPIO=ON && cmake --build build -j",
+  "remoteUser": "root"
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,41 @@
+cmake_minimum_required(VERSION 3.16)
+project(register_mvp LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+option(USE_MOCK_GPIO "Build with a mock GPIO HAL (no libgpiod)" ON)
+
+add_library(hal
+  src/hal/gpio.hpp
+  src/hal/gpio_mock.cpp
+  src/hal/gpio_gpiod.cpp
+)
+
+target_include_directories(hal PUBLIC src)
+
+if(NOT USE_MOCK_GPIO)
+  find_package(PkgConfig REQUIRED)
+  pkg_check_modules(GPIOD REQUIRED libgpiod)
+  target_compile_definitions(hal PUBLIC -DUSE_LIBGPIOD=1)
+  target_include_directories(hal PUBLIC ${GPIOD_INCLUDE_DIRS})
+  target_link_libraries(hal PUBLIC ${GPIOD_LIBRARIES})
+endif()
+
+add_library(drivers
+  src/drivers/stepper.hpp src/drivers/stepper.cpp
+  src/drivers/hopper_parallel.hpp src/drivers/hopper_parallel.cpp
+  src/drivers/hx711.hpp src/drivers/hx711.cpp
+)
+target_link_libraries(drivers PUBLIC hal)
+
+add_executable(register_mvp src/main.cpp)
+target_link_libraries(register_mvp PRIVATE drivers hal pthread)
+
+if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+  target_compile_options(hal PRIVATE -Wall -Wextra -Wpedantic)
+  target_compile_options(drivers PRIVATE -Wall -Wextra -Wpedantic)
+  target_compile_options(register_mvp PRIVATE -Wall -Wextra -Wpedantic)
+endif()
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM debian:bookworm AS build
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       build-essential cmake pkg-config libgpiod-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY . .
+
+ARG USE_MOCK_GPIO=ON
+RUN cmake -S . -B build -DUSE_MOCK_GPIO=${USE_MOCK_GPIO} \
+    && cmake --build build -j
+
+CMD ["./build/register_mvp"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,46 @@
 # DrawerBackend
+
+Minimal C++17 + CMake project demonstrating a stepper-based shutter,
+parallel hopper, and HX711 scale with a mockable GPIO HAL.
+
+## Native build
+
+```bash
+cmake -S . -B build -DUSE_MOCK_GPIO=ON
+cmake --build build -j
+./build/register_mvp
+```
+
+Pass `-DUSE_MOCK_GPIO=OFF` to use libgpiod on hardware (requires `libgpiod-dev`).
+
+## Docker
+
+Build and run with mock GPIO (works on any host that has Docker):
+
+```bash
+docker build -t register_mvp .
+docker run --rm register_mvp
+```
+
+To access real GPIO, build without the mock and map the gpiochip device:
+
+```bash
+docker build -t register_mvp --build-arg USE_MOCK_GPIO=OFF .
+docker run --rm --device /dev/gpiochip0 register_mvp
+```
+
+
+## Dev container
+
+Open the folder in [VS Code Dev Containers](https://code.visualstudio.com/docs/remote/containers) or GitHub Codespaces and the Docker image will build automatically. The container maps `/dev/gpiochip0` and runs:
+
+```
+cmake -S . -B build -DUSE_MOCK_GPIO=ON && cmake --build build -j
+```
+
+so the project is ready to run:
+
+```
+./build/register_mvp
+```
+

--- a/src/drivers/hopper_parallel.cpp
+++ b/src/drivers/hopper_parallel.cpp
@@ -1,0 +1,37 @@
+#include "hopper_parallel.hpp"
+#include <iostream>
+
+HopperParallel::HopperParallel(hal::Chip& chip, int motor_en_pin, int pulse_in_pin, int pulses_per_coin)
+: pulses_per_coin_(pulses_per_coin)
+{
+  en_    = chip.request_line(motor_en_pin, hal::Direction::Out);
+  pulse_ = chip.request_line(pulse_in_pin, hal::Direction::In);
+  en_->write(false); // motor off
+}
+
+bool HopperParallel::dispense(int coins, int max_ms) {
+  const int target_pulses = coins * pulses_per_coin_;
+  int pulses = 0;
+  bool last = pulse_->read();
+  en_->write(true); // start motor
+  auto start = std::chrono::steady_clock::now();
+  while (pulses < target_pulses) {
+    bool cur = false;
+    try { cur = pulse_->read(); } catch(...) { en_->write(false); throw; }
+    if (cur && !last) pulses++; // rising edge
+    last = cur;
+    hal::sleep_us(500); // simple poll; replace with interrupts/epoll later
+
+    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now() - start).count();
+    if (ms > max_ms) {
+      en_->write(false);
+      std::cerr << "[HOPPER] Timeout after " << ms << " ms ("<<pulses<<"/"<<target_pulses<<" pulses)\n";
+      return false;
+    }
+  }
+  en_->write(false);
+  std::cerr << "[HOPPER] Dispensed " << coins << " coin(s)\n";
+  return true;
+}
+

--- a/src/drivers/hopper_parallel.hpp
+++ b/src/drivers/hopper_parallel.hpp
@@ -1,0 +1,19 @@
+#pragma once
+#include "../hal/gpio.hpp"
+#include <cstdint>
+#include <chrono>
+
+class HopperParallel {
+public:
+  // motor_en: output to MOSFET/relay (true=run), pulse_in: optic sensor pulses per coin (usually >1; we use edges)
+  HopperParallel(hal::Chip& chip, int motor_en_pin, int pulse_in_pin, int pulses_per_coin = 1);
+
+  // Dispense N coins with max safety timeout (ms). Returns true if success.
+  bool dispense(int coins, int max_ms = 5000);
+
+private:
+  hal::Line* en_{};
+  hal::Line* pulse_{};
+  int pulses_per_coin_{};
+};
+

--- a/src/drivers/hx711.cpp
+++ b/src/drivers/hx711.cpp
@@ -1,0 +1,36 @@
+#include "hx711.hpp"
+#include <stdexcept>
+
+HX711::HX711(hal::Chip& chip, int dt_pin, int sck_pin, int gain)
+: gain_(gain)
+{
+  dt_  = chip.request_line(dt_pin,  hal::Direction::In);
+  sck_ = chip.request_line(sck_pin, hal::Direction::Out);
+  sck_->write(false);
+}
+
+long HX711::read_raw() {
+  // wait for data ready (DT goes low)
+  int guard = 0;
+  while (dt_->read()) { hal::sleep_us(10); if(++guard > 500000) throw std::runtime_error("HX711 data not ready"); }
+  long val = 0;
+  for (int i=0; i<24; ++i) {
+    sck_->write(true);
+    hal::busy_wait_us(1);
+    val = (val << 1) | (dt_->read() ? 1 : 0);
+    sck_->write(false);
+    hal::busy_wait_us(1);
+  }
+  // set gain|channel by extra pulses
+  int pulses = (gain_==128 ? 1 : (gain_==64 ? 3 : 2));
+  for(int i=0;i<pulses;i++){ sck_->write(true); hal::busy_wait_us(1); sck_->write(false); hal::busy_wait_us(1); }
+  if (val & 0x800000) val |= ~0xFFFFFF; // sign extend
+  return val;
+}
+
+long HX711::read_average(int times) {
+  long sum = 0;
+  for(int i=0;i<times;i++) sum += read_raw();
+  return sum / times;
+}
+

--- a/src/drivers/hx711.hpp
+++ b/src/drivers/hx711.hpp
@@ -1,0 +1,17 @@
+#pragma once
+#include "../hal/gpio.hpp"
+#include <cstdint>
+
+class HX711 {
+public:
+  // dt_pin: data, sck_pin: clock; gain=128 channel A default
+  HX711(hal::Chip& chip, int dt_pin, int sck_pin, int gain = 128);
+  long read_raw();
+  long read_average(int times = 8);
+
+private:
+  hal::Line* dt_{};
+  hal::Line* sck_{};
+  int gain_{};
+};
+

--- a/src/drivers/stepper.cpp
+++ b/src/drivers/stepper.cpp
@@ -1,0 +1,65 @@
+#include "stepper.hpp"
+#include <iostream>
+
+Stepper::Stepper(hal::Chip& chip, int pstep, int pdir, int penable, int plim_open, int plim_closed,
+                 int steps_per_mm, int pulse_us)
+: steps_per_mm_(steps_per_mm), pulse_us_(pulse_us)
+{
+  step_ = chip.request_line(pstep, hal::Direction::Out);
+  dir_  = chip.request_line(pdir,  hal::Direction::Out);
+  en_   = chip.request_line(penable, hal::Direction::Out);
+  lim_open_   = chip.request_line(plim_open,   hal::Direction::In);
+  lim_closed_ = chip.request_line(plim_closed, hal::Direction::In);
+  enable(false); // disable driver initially (DRV8825 EN high disables)
+}
+
+void Stepper::enable(bool en) { en_->write(!en); } // active-low enable
+void Stepper::set_dir(bool open_dir) { dir_->write(open_dir); }
+void Stepper::step(int microsteps) {
+  for(int i=0;i<microsteps;i++){
+    step_->write(true);
+    hal::busy_wait_us(pulse_us_);
+    step_->write(false);
+    hal::busy_wait_us(pulse_us_);
+  }
+}
+bool Stepper::at_open()   const { return lim_open_->read(); }
+bool Stepper::at_closed() const { return lim_closed_->read(); }
+
+bool Stepper::home_closed(int max_mm) {
+  enable(true);
+  set_dir(false); // assume false==toward closed
+  int max_steps = max_mm * steps_per_mm_;
+  for(int i=0;i<max_steps;i++){
+    if (at_closed()) { std::cerr<<"[STEP] Homed CLOSED\n"; enable(false); return true; }
+    const_cast<Stepper*>(this)->step();
+  }
+  std::cerr<<"[STEP] Home CLOSED timeout\n";
+  enable(false);
+  return false;
+}
+
+bool Stepper::open_mm(int mm){
+  enable(true);
+  set_dir(true);
+  int steps = mm * steps_per_mm_;
+  for(int i=0;i<steps;i++){
+    if (at_open()) { std::cerr<<"[STEP] Hit OPEN limit early at "<<i<<" steps\n"; break; }
+    step();
+  }
+  enable(false);
+  return true;
+}
+
+bool Stepper::close_mm(int mm){
+  enable(true);
+  set_dir(false);
+  int steps = mm * steps_per_mm_;
+  for(int i=0;i<steps;i++){
+    if (at_closed()) { std::cerr<<"[STEP] Hit CLOSED limit early at "<<i<<" steps\n"; break; }
+    step();
+  }
+  enable(false);
+  return true;
+}
+

--- a/src/drivers/stepper.hpp
+++ b/src/drivers/stepper.hpp
@@ -1,0 +1,34 @@
+#pragma once
+#include "../hal/gpio.hpp"
+#include <cstdint>
+#include <chrono>
+#include <string>
+
+class Stepper {
+public:
+  // DRV8825 style: step, dir, enable (active-low), two endstops (NC or NO; we read truth directly)
+  Stepper(hal::Chip& chip, int pin_step, int pin_dir, int pin_enable,
+          int pin_limit_open, int pin_limit_closed,
+          int steps_per_mm, int pulse_us=400);
+
+  void enable(bool en);
+  void set_dir(bool open_direction);
+  void step(int microsteps = 1); // blocking pulse
+  bool at_open() const;
+  bool at_closed() const;
+
+  // Basic moves
+  bool home_closed(int max_mm);   // move toward CLOSED until limit; returns success
+  bool open_mm(int mm);           // move toward OPEN measured by steps
+  bool close_mm(int mm);
+
+private:
+  hal::Line* step_{};
+  hal::Line* dir_{};
+  hal::Line* en_{};
+  hal::Line* lim_open_{};
+  hal::Line* lim_closed_{};
+  int steps_per_mm_{};
+  int pulse_us_{};
+};
+

--- a/src/hal/gpio.hpp
+++ b/src/hal/gpio.hpp
@@ -1,0 +1,37 @@
+#pragma once
+#include <cstdint>
+#include <chrono>
+#include <string>
+#include <memory>
+
+// Simple GPIO HAL. When USE_LIBGPIOD is defined we use libgpiod v1.
+// Otherwise, a mock prints actions (handy on laptops).
+
+namespace hal {
+
+enum class Direction { In, Out };
+enum class Pull { None, Up, Down }; // pull ignored in this minimal v1 gpiod impl
+enum class Edge { None, Rising, Falling, Both };
+
+class Line {
+public:
+  virtual ~Line() = default;
+  virtual void write(bool value) = 0;
+  virtual bool read() = 0;
+};
+
+class Chip {
+public:
+  virtual ~Chip() = default;
+  virtual Line* request_line(int gpio, Direction dir, Pull pull = Pull::None,
+                             const std::string& name = "register_mvp") = 0;
+};
+
+std::unique_ptr<Chip> make_chip(const std::string& chip_name_or_path = "gpiochip0");
+
+// Utility helpers
+void sleep_us(uint64_t us);
+void busy_wait_us(uint64_t us);
+
+} // namespace hal
+

--- a/src/hal/gpio_gpiod.cpp
+++ b/src/hal/gpio_gpiod.cpp
@@ -1,0 +1,73 @@
+#include "gpio.hpp"
+#ifdef USE_LIBGPIOD
+#include <gpiod.h>
+#include <stdexcept>
+#include <iostream>
+#include <thread>
+#include <vector>
+
+namespace hal {
+
+class GpiodLine : public Line {
+public:
+  GpiodLine(gpiod_line* ln, bool is_out) : line_(ln), is_out_(is_out) {}
+  ~GpiodLine() override {
+    if (line_) gpiod_line_release(line_);
+  }
+  void write(bool v) override {
+    if (!is_out_) throw std::runtime_error("write on input line");
+    if (gpiod_line_set_value(line_, v ? 1 : 0) < 0) throw std::runtime_error("gpiod_line_set_value failed");
+  }
+  bool read() override {
+    int r = gpiod_line_get_value(line_);
+    if (r < 0) throw std::runtime_error("gpiod_line_get_value failed");
+    return r == 1;
+  }
+private:
+  gpiod_line* line_{};
+  bool is_out_{};
+};
+
+class GpiodChip : public Chip {
+public:
+  explicit GpiodChip(const std::string& name) {
+    chip_ = gpiod_chip_open_by_name(name.c_str());
+    if (!chip_) {
+      // also try path
+      chip_ = gpiod_chip_open(name.c_str());
+    }
+    if (!chip_) throw std::runtime_error("Failed to open gpiochip: " + name);
+  }
+  ~GpiodChip() override {
+    if (chip_) gpiod_chip_close(chip_);
+  }
+  Line* request_line(int gpio, Direction dir, Pull, const std::string& name) override {
+    gpiod_line* ln = gpiod_chip_get_line(chip_, gpio);
+    if (!ln) throw std::runtime_error("gpiod_chip_get_line failed");
+    int rc;
+    if (dir == Direction::Out)
+      rc = gpiod_line_request_output(ln, name.c_str(), 0);
+    else
+      rc = gpiod_line_request_input(ln, name.c_str());
+    if (rc < 0) throw std::runtime_error("gpiod_line_request_* failed");
+    owned_.emplace_back(std::unique_ptr<GpiodLine>(new GpiodLine(ln, dir==Direction::Out)));
+    return owned_.back().get();
+  }
+private:
+  gpiod_chip* chip_{};
+  std::vector<std::unique_ptr<GpiodLine>> owned_;
+};
+
+std::unique_ptr<Chip> make_chip(const std::string& name) { return std::unique_ptr<Chip>(new GpiodChip(name)); }
+
+void sleep_us(uint64_t us) { std::this_thread::sleep_for(std::chrono::microseconds(us)); }
+void busy_wait_us(uint64_t us) {
+  auto start = std::chrono::steady_clock::now();
+  while (std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now()-start).count() < (long long)us) {}
+}
+
+} // namespace hal
+#else
+// compiled out if not using libgpiod
+#endif
+

--- a/src/hal/gpio_mock.cpp
+++ b/src/hal/gpio_mock.cpp
@@ -1,0 +1,37 @@
+#include "gpio.hpp"
+#ifndef USE_LIBGPIOD
+#include <iostream>
+#include <memory>
+#include <thread>
+#include <vector>
+
+namespace hal {
+
+class MockLine : public Line {
+public:
+  MockLine(int id, bool out) : id_(id), out_(out) {}
+  void write(bool v) override { if(out_) { val_=v; std::cerr<<"[MOCK GPIO] set "<<id_<<"="<<v<<"\n"; } }
+  bool read() override { std::cerr<<"[MOCK GPIO] read "<<id_<<" -> "<<val_<<"\n"; return val_; }
+private:
+  int id_; bool out_; bool val_{false};
+};
+
+class MockChip : public Chip {
+public:
+  Line* request_line(int gpio, Direction dir, Pull, const std::string& name) override {
+    (void)name;
+    owned_.emplace_back(std::unique_ptr<MockLine>(new MockLine(gpio, dir==Direction::Out)));
+    return owned_.back().get();
+  }
+private:
+  std::vector<std::unique_ptr<MockLine>> owned_;
+};
+
+std::unique_ptr<Chip> make_chip(const std::string&) { return std::unique_ptr<Chip>(new MockChip()); }
+
+void sleep_us(uint64_t us) { std::this_thread::sleep_for(std::chrono::microseconds(us)); }
+void busy_wait_us(uint64_t us) { sleep_us(us); }
+
+} // namespace hal
+#endif
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,73 @@
+#include "drivers/stepper.hpp"
+#include "drivers/hopper_parallel.hpp"
+#include "drivers/hx711.hpp"
+#include "hal/gpio.hpp"
+#include <iostream>
+
+// ==== PIN MAP (BCM or "GPIO line numbers" depending on chip, adjust to your wiring) ====
+// libgpiod numbering refers to the "line offset" on gpiochip0. Update these to match your Pi header mapping.
+static constexpr int PIN_STEP      = 23;  // stepper STEP
+static constexpr int PIN_DIR       = 24;  // stepper DIR
+static constexpr int PIN_ENABLE    = 25;  // stepper EN (active-low)
+static constexpr int PIN_LIMIT_O   = 26;  // OPEN limit switch (true when pressed)
+static constexpr int PIN_LIMIT_C   = 27;  // CLOSED limit switch
+
+static constexpr int PIN_HOPPER_EN = 5;   // drive MOSFET/relay for hopper motor (true=on)
+static constexpr int PIN_HOPPER_P  = 6;   // optic pulse input (TTL via opto/level shifter)
+
+static constexpr int PIN_HX_DT     = 19;  // HX711 DT
+static constexpr int PIN_HX_SCK    = 13;  // HX711 SCK
+
+int main() {
+  try {
+    auto chip = hal::make_chip("gpiochip0");
+
+    // Init drivers
+    Stepper shutter(*chip, PIN_STEP, PIN_DIR, PIN_ENABLE, PIN_LIMIT_O, PIN_LIMIT_C,
+                    /*steps_per_mm=*/40, /*pulse_us=*/400);
+    HopperParallel hopper(*chip, PIN_HOPPER_EN, PIN_HOPPER_P, /*pulses_per_coin=*/1);
+    HX711 scale(*chip, PIN_HX_DT, PIN_HX_SCK);
+
+    // --- Demo sequence ---
+    std::cerr << "[BOOT] Homing shutter to CLOSED...\n";
+    if (!shutter.home_closed(/*max_mm=*/80)) {
+      std::cerr << "[FAIL] Could not home shutter. Check wiring/limits.\n";
+      return 1;
+    }
+
+    std::cerr << "[STEP] Opening shutter 40mm for self-test...\n";
+    shutter.open_mm(40);
+    hal::sleep_us(300000);
+    std::cerr << "[STEP] Closing shutter...\n";
+    shutter.close_mm(40);
+
+    // Read scale baseline
+    long base = 0;
+    try { base = scale.read_average(4); std::cerr << "[SCALE] Baseline="<< base << "\n"; }
+    catch(...) { std::cerr << "[SCALE] Skipping scale (not wired?)\n"; }
+
+    // Dispense change: 3 quarters
+    std::cerr << "[HOPPER] Dispensing 3 coins...\n";
+    if (!hopper.dispense(3, /*max_ms=*/5000)) {
+      std::cerr << "[FAIL] Hopper timeout or sensor issue.\n";
+    }
+
+    // Open shutter to present change
+    shutter.open_mm(40);
+    hal::sleep_us(2000000); // 2s for customer to take coins
+    shutter.close_mm(40);
+
+    // Audit weight delta
+    try {
+      long post = scale.read_average(4);
+      std::cerr << "[SCALE] Delta=" << (post - base) << " (raw units)\n";
+    } catch(...) {}
+
+    std::cerr << "[DONE] Demo OK\n";
+    return 0;
+  } catch (const std::exception& e) {
+    std::cerr << "[EXC] " << e.what() << "\n";
+    return 2;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add C++17 CMake project with optional mock or libgpiod GPIO HAL
- implement stepper, hopper, and HX711 drivers with demo main
- add Dockerfile and README instructions for portable builds
- configure VS Code/Codespaces dev container for automatic Docker environment

## Testing
- `cmake -S . -B build -DUSE_MOCK_GPIO=ON`
- `cmake --build build -j`
- `./build/register_mvp` *(fails to home in mock environment due to missing limit switch)*

------
https://chatgpt.com/codex/tasks/task_e_689fc683d67883338678271e8fc20339