### PR TITLE
Include MAC addresses in device ID fallback

### DIFF
--- a/src/cloud/identity.cpp
+++ b/src/cloud/identity.cpp
@@ -3,6 +3,7 @@
 #include <sstream>
 #include <iomanip>
 #include <functional>
+#include <cstdlib>
 
 namespace cloud {
 namespace {
@@ -22,6 +23,8 @@ std::string device_id(const cfg::Config& c) {
   } else {
     const char* cpu = std::getenv("RMVP_CPU_SERIAL");
     if (cpu) raw += cpu;
+    const char* macs = std::getenv("RMVP_MACS");
+    if (macs) raw += macs;
     const char* mid = std::getenv("RMVP_MACHINE_ID");
     if (mid) raw += mid;
     else {


### PR DESCRIPTION
### **User description**
## Summary
- incorporate MAC address data into device ID derivation when TPM is unavailable

## Testing
- `cmake -S .. -DBUILD_TESTING=ON -DUSE_MOCK_GPIO=ON`
- `cmake --build . -j`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68a0dbee6ef483338f2344160f6773ea


___

### **PR Type**
Enhancement


___

### **Description**
- Add MAC address data to device ID fallback mechanism

- Include `RMVP_MACS` environment variable in device identification

- Enhance security hardening for device identification when TPM unavailable


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Environment Variables"] --> B["Device ID Generation"]
  C["RMVP_CPU_SERIAL"] --> B
  D["RMVP_MACS"] --> B
  E["RMVP_MACHINE_ID"] --> B
  F["/etc/machine-id"] --> B
  B --> G["Hashed Device ID"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>identity.cpp</strong><dd><code>Add MAC addresses to device identification</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/cloud/identity.cpp

<ul><li>Add <code>#include <cstdlib></code> for environment variable access<br> <li> Include <code>RMVP_MACS</code> environment variable in device ID generation<br> <li> Append MAC address data to raw string when available</ul>


</details>


  </td>
  <td><a href="https://github.com/zveasy/DrawerBackend/pull/17/files#diff-57774e053c94f11786133b5b9eb22b731bf716cd8adfd617a726b52d076db015">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

