### PR TITLE
Add Docker Compose setup for cross-platform development

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,20 @@ docker build -t register_mvp --build-arg USE_MOCK_GPIO=OFF .
 docker run --rm --device /dev/gpiochip0 register_mvp
 ```
 
+For a persistent development container that works across operating systems, use
+the included Docker Compose file:
+
+```bash
+docker compose up -d --build
+docker compose exec drawerbackend bash
+```
+
+When you're finished, shut down the container with:
+
+```bash
+docker compose down
+```
+
 
 
 ## Dev container

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3.8"
+services:
+  drawerbackend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - .:/workspace/DrawerBackend
+    working_dir: /workspace/DrawerBackend
+    command: sleep infinity
+    devices:
+      - "/dev/gpiochip0:/dev/gpiochip0"


### PR DESCRIPTION
## Summary
- add `docker-compose.yml` for a persistent development container
- document how to start/stop the container with Docker Compose

## Testing
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a21e581540833383422d9b0bb345af