### PR TITLE
Use JSON parsing in HTTP server and test malformed input

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,10 @@ add_library(server
 )
 target_include_directories(server PUBLIC . src)
 target_link_libraries(server PUBLIC app httplib::httplib Threads::Threads obs mfg OpenSSL::SSL OpenSSL::Crypto)
+if(USE_NLOHMANN_JSON)
+  target_link_libraries(server PUBLIC nlohmann_json::nlohmann_json)
+  target_compile_definitions(server PUBLIC USE_NLOHMANN_JSON=1)
+endif()
 target_compile_definitions(server PUBLIC CPPHTTPLIB_OPENSSL_SUPPORT)
 target_compile_options(server PRIVATE -UCPPHTTPLIB_USE_CERTS_FROM_MACOSX_KEYCHAIN)
 

--- a/tests/http_handlers_test.cpp
+++ b/tests/http_handlers_test.cpp
@@ -39,3 +39,21 @@ TEST(HttpHandlers, BasicFlow) {
 
   srv.stop();
 }
+
+TEST(HttpHandlers, MalformedJson) {
+  std::filesystem::remove_all("data");
+  FakeShutter sh; FakeDispenser disp; TxnConfig cfg; TxnEngine eng(sh, disp, cfg);
+  HttpServer srv(eng, sh, disp); ASSERT_TRUE(srv.start("127.0.0.1", 0));
+  httplib::Client cli("127.0.0.1", srv.port());
+
+  auto bad_txn = cli.Post("/txn", "not json", "application/json");
+  ASSERT_TRUE(bad_txn); EXPECT_EQ(400, bad_txn->status);
+
+  auto bad_cmd = cli.Post("/command", "{\"open\":\"bad\"}", "application/json");
+  ASSERT_TRUE(bad_cmd); EXPECT_EQ(400, bad_cmd->status);
+
+  auto bad_cmd2 = cli.Post("/command", "not json", "application/json");
+  ASSERT_TRUE(bad_cmd2); EXPECT_EQ(400, bad_cmd2->status);
+
+  srv.stop();
+}


### PR DESCRIPTION
### **User description**
## Summary
- parse transaction and command requests with nlohmann::json instead of manual string scanning
- link JSON library when `USE_NLOHMANN_JSON` is enabled
- add tests for malformed JSON requests

## Testing
- `cmake --build build --target http_handlers_test`
- `cd build && ctest -R HttpHandlers -V`


------
https://chatgpt.com/codex/tasks/task_e_68a4c7c4885c8333a9aa7b47b00e6655


___

### **PR Type**
Enhancement


___

### **Description**
- Replace manual string parsing with nlohmann::json library

- Add proper error handling for malformed JSON requests

- Include comprehensive tests for invalid JSON input

- Update CMake configuration for JSON library linking


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Manual String Parsing"] --> B["nlohmann::json Library"]
  B --> C["Improved Error Handling"]
  C --> D["Malformed JSON Tests"]
  E["CMake Config"] --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>http_server.cpp</strong><dd><code>Replace manual parsing with JSON library</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/http_server.cpp

<ul><li>Remove manual <code>get_int_field</code> string parsing function<br> <li> Replace with <code>nlohmann::json::parse()</code> for <code>/txn</code> and <code>/command</code> endpoints<br> <li> Add proper exception handling for JSON parsing errors<br> <li> Improve error responses with structured JSON error messages</ul>


</details>


  </td>
  <td><a href="https://github.com/zveasy/DrawerBackend/pull/29/files#diff-a94706c414f3dd1328e732a780f252700b09b20e18d7fcd79a294447e9e29ae9">+26/-25</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>http_handlers_test.cpp</strong><dd><code>Add malformed JSON input tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/http_handlers_test.cpp

<ul><li>Add <code>MalformedJson</code> test case for invalid JSON inputs<br> <li> Test malformed transaction requests with non-JSON content<br> <li> Test command requests with invalid JSON structure and content<br> <li> Verify proper 400 status codes for bad requests</ul>


</details>


  </td>
  <td><a href="https://github.com/zveasy/DrawerBackend/pull/29/files#diff-f4b8518d824430e621d1db3c23cb6d960735a1b38b883d3f12e120854de32e2e">+18/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CMakeLists.txt</strong><dd><code>Configure nlohmann JSON library linking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CMakeLists.txt

<ul><li>Add conditional linking of <code>nlohmann_json::nlohmann_json</code> library<br> <li> Set <code>USE_NLOHMANN_JSON=1</code> compile definition when enabled<br> <li> Configure JSON library support for server target</ul>


</details>


  </td>
  <td><a href="https://github.com/zveasy/DrawerBackend/pull/29/files#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

