### PR TITLE
Refactor config loader into section parsers and expand tests

### DIFF
--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -5,6 +5,7 @@
 #include <filesystem>
 #include <fstream>
 #include <sstream>
+#include <unordered_map>
 
 namespace cfg {
 
@@ -47,6 +48,332 @@ std::string lower(std::string s) {
   std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c){ return std::tolower(c); });
   return s;
 }
+
+void set_int(int& target, const std::string& value, const std::string& fullkey, Config& cfg) {
+  int def = target;
+  try { target = std::stoi(value); }
+  catch (...) { target = def; cfg.warnings.push_back(fullkey + " invalid, using default " + std::to_string(def)); }
+}
+
+void set_long(long& target, const std::string& value, const std::string& fullkey, Config& cfg) {
+  long def = target;
+  try { target = std::stol(value); }
+  catch (...) { target = def; cfg.warnings.push_back(fullkey + " invalid, using default " + std::to_string(def)); }
+}
+
+void set_double(double& target, const std::string& value, const std::string& fullkey, Config& cfg) {
+  double def = target;
+  try { target = std::stod(value); }
+  catch (...) { target = def; cfg.warnings.push_back(fullkey + " invalid, using default " + std::to_string(def)); }
+}
+
+void set_uint64(uint64_t& target, const std::string& value, const std::string& fullkey, Config& cfg) {
+  uint64_t def = target;
+  try { target = std::stoull(value); }
+  catch (...) { target = def; cfg.warnings.push_back(fullkey + " invalid, using default " + std::to_string(def)); }
+}
+
+void set_bool(bool& target, const std::string& value, const std::string& fullkey, Config& cfg) {
+  bool def = target;
+  try { target = std::stoi(value) != 0; }
+  catch (...) { target = def; cfg.warnings.push_back(fullkey + " invalid, using default " + (def?"1":"0")); }
+}
+
+using Setter = void(*)(Config&, const std::string&, const std::string&);
+using SectionParser = bool(*)(Config&, const std::string&, const std::string&, const std::string&);
+
+bool parse_io_pins(Config& cfg, const std::string& key, const std::string& value, const std::string& fullkey) {
+  static const std::unordered_map<std::string, Setter> map = {
+    {"step", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.pins.step, v, fk, c); }},
+    {"dir", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.pins.dir, v, fk, c); }},
+    {"enable", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.pins.enable, v, fk, c); }},
+    {"limit_open", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.pins.limit_open, v, fk, c); }},
+    {"limit_closed", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.pins.limit_closed, v, fk, c); }},
+    {"hopper_en", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.pins.hopper_en, v, fk, c); }},
+    {"hopper_pulse", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.pins.hopper_pulse, v, fk, c); }},
+    {"hx_dt", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.pins.hx_dt, v, fk, c); }},
+    {"hx_sck", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.pins.hx_sck, v, fk, c); }},
+  };
+  auto it = map.find(key);
+  if (it == map.end()) return false;
+  it->second(cfg, value, fullkey);
+  return true;
+}
+
+bool parse_mechanics(Config& cfg, const std::string& key, const std::string& value, const std::string& fullkey) {
+  static const std::unordered_map<std::string, Setter> map = {
+    {"steps_per_mm", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.mech.steps_per_mm, v, fk, c); }},
+    {"open_mm", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.mech.open_mm, v, fk, c); }},
+    {"max_mm", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.mech.max_mm, v, fk, c); }},
+  };
+  auto it = map.find(key);
+  if (it == map.end()) return false;
+  it->second(cfg, value, fullkey);
+  return true;
+}
+
+bool parse_hopper(Config& cfg, const std::string& key, const std::string& value, const std::string& fullkey) {
+  static const std::unordered_map<std::string, Setter> map = {
+    {"pulses_per_coin", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.hopper.pulses_per_coin, v, fk, c); }},
+    {"min_edge_interval_us", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.hopper.min_edge_interval_us, v, fk, c); }},
+  };
+  auto it = map.find(key);
+  if (it == map.end()) return false;
+  it->second(cfg, value, fullkey);
+  return true;
+}
+
+bool parse_dispense(Config& cfg, const std::string& key, const std::string& value, const std::string& fullkey) {
+  static const std::unordered_map<std::string, Setter> map = {
+    {"jam_ms", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.disp.jam_ms, v, fk, c); }},
+    {"settle_ms", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.disp.settle_ms, v, fk, c); }},
+    {"max_ms_per_coin", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.disp.max_ms_per_coin, v, fk, c); }},
+    {"hard_timeout_ms", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.disp.hard_timeout_ms, v, fk, c); }},
+  };
+  auto it = map.find(key);
+  if (it == map.end()) return false;
+  it->second(cfg, value, fullkey);
+  return true;
+}
+
+bool parse_audit(Config& cfg, const std::string& key, const std::string& value, const std::string& fullkey) {
+  static const std::unordered_map<std::string, Setter> map = {
+    {"coin_mass_g", [](Config& c, const std::string& v, const std::string& fk){ set_double(c.audit.coin_mass_g, v, fk, c); }},
+    {"tolerance_per_coin_g", [](Config& c, const std::string& v, const std::string& fk){ set_double(c.audit.tolerance_per_coin_g, v, fk, c); }},
+    {"grams_per_raw", [](Config& c, const std::string& v, const std::string& fk){ set_double(c.audit.grams_per_raw, v, fk, c); }},
+    {"tare_raw", [](Config& c, const std::string& v, const std::string& fk){ set_long(c.audit.tare_raw, v, fk, c); }},
+    {"samples_pre", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.audit.samples_pre, v, fk, c); }},
+    {"samples_post", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.audit.samples_post, v, fk, c); }},
+    {"settle_ms", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.audit.settle_ms, v, fk, c); }},
+    {"stuck_epsilon_raw", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.audit.stuck_epsilon_raw, v, fk, c); }},
+  };
+  auto it = map.find(key);
+  if (it == map.end()) return false;
+  it->second(cfg, value, fullkey);
+  return true;
+}
+
+bool parse_presentation(Config& cfg, const std::string& key, const std::string& value, const std::string& fullkey) {
+  static const std::unordered_map<std::string, Setter> map = {
+    {"present_ms", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.pres.present_ms, v, fk, c); }},
+  };
+  auto it = map.find(key);
+  if (it == map.end()) return false;
+  it->second(cfg, value, fullkey);
+  return true;
+}
+
+bool parse_selftest(Config& cfg, const std::string& key, const std::string& value, const std::string& fullkey) {
+  static const std::unordered_map<std::string, Setter> map = {
+    {"enable_coin_test", [](Config& c, const std::string& v, const std::string& fk){ set_bool(c.st.enable_coin_test, v, fk, c); }},
+  };
+  auto it = map.find(key);
+  if (it == map.end()) return false;
+  it->second(cfg, value, fullkey);
+  return true;
+}
+
+bool parse_aws(Config& cfg, const std::string& key, const std::string& value, const std::string& fullkey) {
+  static const std::unordered_map<std::string, Setter> map = {
+    {"enable", [](Config& c, const std::string& v, const std::string& fk){ set_bool(c.aws.enable, v, fk, c); }},
+    {"endpoint", [](Config& c, const std::string& v, const std::string&){ c.aws.endpoint = v; }},
+    {"thing_name", [](Config& c, const std::string& v, const std::string&){ c.aws.thing_name = v; }},
+    {"client_id", [](Config& c, const std::string& v, const std::string&){ c.aws.client_id = v; }},
+    {"root_ca", [](Config& c, const std::string& v, const std::string&){ c.aws.root_ca = v; }},
+    {"cert", [](Config& c, const std::string& v, const std::string&){ c.aws.cert = v; }},
+    {"key", [](Config& c, const std::string& v, const std::string&){ c.aws.key = v; }},
+    {"topic_prefix", [](Config& c, const std::string& v, const std::string&){ c.aws.topic_prefix = v; }},
+    {"qos", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.aws.qos, v, fk, c); }},
+    {"queue_dir", [](Config& c, const std::string& v, const std::string&){ c.aws.queue_dir = v; }},
+    {"max_queue_bytes", [](Config& c, const std::string& v, const std::string& fk){ set_uint64(c.aws.max_queue_bytes, v, fk, c); }},
+    {"use_tls_identity", [](Config& c, const std::string& v, const std::string& fk){ set_bool(c.aws.use_tls_identity, v, fk, c); }},
+    {"rotation_check_minutes", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.aws.rotation_check_minutes, v, fk, c); }},
+  };
+  auto it = map.find(key);
+  if (it == map.end()) return false;
+  it->second(cfg, value, fullkey);
+  return true;
+}
+
+bool parse_security(Config& cfg, const std::string& key, const std::string& value, const std::string& fullkey) {
+  static const std::unordered_map<std::string, Setter> map = {
+    {"enable_ro_root", [](Config& c, const std::string& v, const std::string& fk){ set_bool(c.security.enable_ro_root, v, fk, c); }},
+    {"ssh_keys_only", [](Config& c, const std::string& v, const std::string& fk){ set_bool(c.security.ssh_keys_only, v, fk, c); }},
+    {"firewall_enable", [](Config& c, const std::string& v, const std::string& fk){ set_bool(c.security.firewall_enable, v, fk, c); }},
+    {"allow_ssh_from", [](Config& c, const std::string& v, const std::string&){ c.security.allow_ssh_from = v; }},
+    {"auditd_enable", [](Config& c, const std::string& v, const std::string& fk){ set_bool(c.security.auditd_enable, v, fk, c); }},
+    {"service_user", [](Config& c, const std::string& v, const std::string&){ c.security.service_user = v; }},
+  };
+  auto it = map.find(key);
+  if (it == map.end()) return false;
+  it->second(cfg, value, fullkey);
+  return true;
+}
+
+bool parse_identity(Config& cfg, const std::string& key, const std::string& value, const std::string& fullkey) {
+  static const std::unordered_map<std::string, Setter> map = {
+    {"use_tpm", [](Config& c, const std::string& v, const std::string& fk){ set_bool(c.identity.use_tpm, v, fk, c); }},
+    {"tpm_parent_handle", [](Config& c, const std::string& v, const std::string&){ c.identity.tpm_parent_handle = v; }},
+    {"ca_endpoint", [](Config& c, const std::string& v, const std::string&){ c.identity.ca_endpoint = v; }},
+    {"cert_dir", [](Config& c, const std::string& v, const std::string&){ c.identity.cert_dir = v; }},
+    {"device_id_prefix", [](Config& c, const std::string& v, const std::string&){ c.identity.device_id_prefix = v; }},
+  };
+  auto it = map.find(key);
+  if (it == map.end()) return false;
+  it->second(cfg, value, fullkey);
+  return true;
+}
+
+bool parse_safety(Config& cfg, const std::string& key, const std::string& value, const std::string& fullkey) {
+  static const std::unordered_map<std::string, Setter> map = {
+    {"estop_pin", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.safety.estop_pin, v, fk, c); }},
+    {"lid_tamper_pin", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.safety.lid_tamper_pin, v, fk, c); }},
+    {"overcurrent_pin", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.safety.overcurrent_pin, v, fk, c); }},
+    {"debounce_ms", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.safety.debounce_ms, v, fk, c); }},
+    {"active_high", [](Config& c, const std::string& v, const std::string& fk){ set_bool(c.safety.active_high, v, fk, c); }},
+  };
+  auto it = map.find(key);
+  if (it == map.end()) return false;
+  it->second(cfg, value, fullkey);
+  return true;
+}
+
+bool parse_service(Config& cfg, const std::string& key, const std::string& value, const std::string& fullkey) {
+  static const std::unordered_map<std::string, Setter> map = {
+    {"enable", [](Config& c, const std::string& v, const std::string& fk){ set_bool(c.service.enable, v, fk, c); }},
+    {"pin_code", [](Config& c, const std::string& v, const std::string&){ c.service.pin_code = v; }},
+    {"jam_clear_shutter_mm", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.service.jam_clear_shutter_mm, v, fk, c); }},
+    {"jam_clear_cycles", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.service.jam_clear_cycles, v, fk, c); }},
+    {"hopper_nudge_ms", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.service.hopper_nudge_ms, v, fk, c); }},
+    {"hopper_max_retries", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.service.hopper_max_retries, v, fk, c); }},
+    {"audit_path", [](Config& c, const std::string& v, const std::string&){ c.service.audit_path = v; }},
+  };
+  auto it = map.find(key);
+  if (it == map.end()) return false;
+  it->second(cfg, value, fullkey);
+  return true;
+}
+
+bool parse_pos(Config& cfg, const std::string& key, const std::string& value, const std::string& fullkey) {
+  static const std::unordered_map<std::string, Setter> map = {
+    {"enable_http", [](Config& c, const std::string& v, const std::string& fk){ set_bool(c.pos.enable_http, v, fk, c); }},
+    {"port", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.pos.port, v, fk, c); }},
+    {"key", [](Config& c, const std::string& v, const std::string&){ c.pos.key = v; }},
+    {"tls_cert", [](Config& c, const std::string& v, const std::string&){ c.pos.tls_cert = v; }},
+    {"tls_key", [](Config& c, const std::string& v, const std::string&){ c.pos.tls_key = v; }},
+  };
+  auto it = map.find(key);
+  if (it == map.end()) return false;
+  it->second(cfg, value, fullkey);
+  return true;
+}
+
+bool parse_ota(Config& cfg, const std::string& key, const std::string& value, const std::string& fullkey) {
+  static const std::unordered_map<std::string, Setter> map = {
+    {"enable", [](Config& c, const std::string& v, const std::string& fk){ set_bool(c.ota.enable, v, fk, c); }},
+    {"backend", [](Config& c, const std::string& v, const std::string&){ c.ota.backend = v; }},
+    {"feed_url", [](Config& c, const std::string& v, const std::string&){ c.ota.feed_url = v; }},
+    {"channel", [](Config& c, const std::string& v, const std::string&){ c.ota.channel = v; }},
+    {"ring", [](Config& c, const std::string& v, const std::string&){ c.ota.ring = v; }},
+    {"poll_seconds", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.ota.poll_seconds, v, fk, c); }},
+    {"state_dir", [](Config& c, const std::string& v, const std::string&){ c.ota.state_dir = v; }},
+    {"key_pub", [](Config& c, const std::string& v, const std::string&){ c.ota.key_pub = v; }},
+    {"health_grace_seconds", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.ota.health_grace_seconds, v, fk, c); }},
+    {"require_signed", [](Config& c, const std::string& v, const std::string& fk){ set_bool(c.ota.require_signed, v, fk, c); }},
+  };
+  auto it = map.find(key);
+  if (it == map.end()) return false;
+  it->second(cfg, value, fullkey);
+  return true;
+}
+
+bool parse_manufacturing(Config& cfg, const std::string& key, const std::string& value, const std::string& fullkey) {
+  static const std::unordered_map<std::string, Setter> map = {
+    {"enable_first_boot_eol", [](Config& c, const std::string& v, const std::string& fk){ set_bool(c.mfg.enable_first_boot_eol, v, fk, c); }},
+    {"label_printer_uri", [](Config& c, const std::string& v, const std::string&){ c.mfg.label_printer_uri = v; }},
+    {"label_template", [](Config& c, const std::string& v, const std::string&){ c.mfg.label_template = v; }},
+    {"company_name", [](Config& c, const std::string& v, const std::string&){ c.mfg.company_name = v; }},
+  };
+  auto it = map.find(key);
+  if (it == map.end()) return false;
+  it->second(cfg, value, fullkey);
+  return true;
+}
+
+bool parse_eol(Config& cfg, const std::string& key, const std::string& value, const std::string& fullkey) {
+  static const std::unordered_map<std::string, Setter> map = {
+    {"weigh_tolerance_g", [](Config& c, const std::string& v, const std::string& fk){ set_double(c.eol.weigh_tolerance_g, v, fk, c); }},
+    {"coins_for_test", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.eol.coins_for_test, v, fk, c); }},
+    {"open_mm", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.eol.open_mm, v, fk, c); }},
+    {"present_ms", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.eol.present_ms, v, fk, c); }},
+    {"retries", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.eol.retries, v, fk, c); }},
+    {"min_success_txn_visible_seconds", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.eol.min_success_txn_visible_seconds, v, fk, c); }},
+    {"result_dir", [](Config& c, const std::string& v, const std::string&){ c.eol.result_dir = v; }},
+  };
+  auto it = map.find(key);
+  if (it == map.end()) return false;
+  it->second(cfg, value, fullkey);
+  return true;
+}
+
+bool parse_burnin(Config& cfg, const std::string& key, const std::string& value, const std::string& fullkey) {
+  static const std::unordered_map<std::string, Setter> map = {
+    {"cycles", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.burnin.cycles, v, fk, c); }},
+    {"rest_ms", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.burnin.rest_ms, v, fk, c); }},
+    {"abort_on_fault", [](Config& c, const std::string& v, const std::string& fk){ set_bool(c.burnin.abort_on_fault, v, fk, c); }},
+    {"log_path", [](Config& c, const std::string& v, const std::string&){ c.burnin.log_path = v; }},
+  };
+  auto it = map.find(key);
+  if (it == map.end()) return false;
+  it->second(cfg, value, fullkey);
+  return true;
+}
+
+bool parse_quant(Config& cfg, const std::string& key, const std::string& value, const std::string& fullkey) {
+  static const std::unordered_map<std::string, Setter> map = {
+    {"enable", [](Config& c, const std::string& v, const std::string& fk){ set_bool(c.quant.enable, v, fk, c); }},
+    {"endpoint", [](Config& c, const std::string& v, const std::string&){ c.quant.endpoint = v; }},
+    {"client_id", [](Config& c, const std::string& v, const std::string&){ c.quant.client_id = v; }},
+    {"hmac_key_hex", [](Config& c, const std::string& v, const std::string&){ c.quant.hmac_key_hex = v; }},
+    {"topic", [](Config& c, const std::string& v, const std::string&){ c.quant.topic = v; }},
+    {"queue_dir", [](Config& c, const std::string& v, const std::string&){ c.quant.queue_dir = v; }},
+    {"backoff_ms", [](Config& c, const std::string& v, const std::string&){ c.quant.backoff_ms = v; }},
+    {"heartbeat_seconds", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.quant.heartbeat_seconds, v, fk, c); }},
+    {"reserve_floor_cents", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.quant.reserve_floor_cents, v, fk, c); }},
+    {"max_daily_outflow_cents", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.quant.max_daily_outflow_cents, v, fk, c); }},
+    {"min_step_change_cents", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.quant.min_step_change_cents, v, fk, c); }},
+    {"max_update_rate_hz", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.quant.max_update_rate_hz, v, fk, c); }},
+    {"tolerance_cents", [](Config& c, const std::string& v, const std::string& fk){ set_int(c.quant.tolerance_cents, v, fk, c); }},
+    {"client_public", [](Config&, const std::string&, const std::string&){ /* accepted but ignored */ }},
+    {"client_secret", [](Config&, const std::string&, const std::string&){ /* accepted but ignored */ }},
+    {"server_public", [](Config&, const std::string&, const std::string&){ /* accepted but ignored */ }},
+  };
+  auto it = map.find(key);
+  if (it == map.end()) return false;
+  it->second(cfg, value, fullkey);
+  return true;
+}
+
+const std::unordered_map<std::string, SectionParser> section_parsers = {
+  {"io.pins", parse_io_pins},
+  {"mechanics", parse_mechanics},
+  {"hopper", parse_hopper},
+  {"dispense", parse_dispense},
+  {"audit", parse_audit},
+  {"presentation", parse_presentation},
+  {"selftest", parse_selftest},
+  {"aws", parse_aws},
+  {"security", parse_security},
+  {"identity", parse_identity},
+  {"safety", parse_safety},
+  {"service", parse_service},
+  {"pos", parse_pos},
+  {"ota", parse_ota},
+  {"manufacturing", parse_manufacturing},
+  {"eol", parse_eol},
+  {"burnin", parse_burnin},
+  {"quant", parse_quant},
+};
 
 } // namespace
 
@@ -93,413 +420,13 @@ Config load() {
       auto fullkey = section + "." + key;
       bool handled = false;
       try {
-        if (section == "io.pins") {
-          handled = true;
-          int* target = nullptr;
-          if (key == "step") target = &cfg.pins.step;
-          else if (key == "dir") target = &cfg.pins.dir;
-          else if (key == "enable") target = &cfg.pins.enable;
-          else if (key == "limit_open") target = &cfg.pins.limit_open;
-          else if (key == "limit_closed") target = &cfg.pins.limit_closed;
-          else if (key == "hopper_en") target = &cfg.pins.hopper_en;
-          else if (key == "hopper_pulse") target = &cfg.pins.hopper_pulse;
-          else if (key == "hx_dt") target = &cfg.pins.hx_dt;
-          else if (key == "hx_sck") target = &cfg.pins.hx_sck;
-          else handled = false;
-          if (target) {
-            int def = *target;
-            try { *target = std::stoi(value); }
-            catch (...) { *target = def; cfg.warnings.push_back(fullkey + " invalid, using default " + std::to_string(def)); }
-          }
-        } else if (section == "mechanics") {
-          handled = true;
-          int* target = nullptr;
-          if (key == "steps_per_mm") target = &cfg.mech.steps_per_mm;
-          else if (key == "open_mm") target = &cfg.mech.open_mm;
-          else if (key == "max_mm") target = &cfg.mech.max_mm;
-          else handled = false;
-          if (target) {
-            int def = *target;
-            try { *target = std::stoi(value); }
-            catch (...) { *target = def; cfg.warnings.push_back(fullkey + " invalid, using default " + std::to_string(def)); }
-          }
-        } else if (section == "hopper") {
-          handled = true;
-          int* target = nullptr;
-          if (key == "pulses_per_coin") target = &cfg.hopper.pulses_per_coin;
-          else if (key == "min_edge_interval_us") target = &cfg.hopper.min_edge_interval_us;
-          else handled = false;
-          if (target) {
-            int def = *target;
-            try { *target = std::stoi(value); }
-            catch (...) { *target = def; cfg.warnings.push_back(fullkey + " invalid, using default " + std::to_string(def)); }
-          }
-        } else if (section == "dispense") {
-          handled = true;
-          int* target = nullptr;
-          if (key == "jam_ms") target = &cfg.disp.jam_ms;
-          else if (key == "settle_ms") target = &cfg.disp.settle_ms;
-          else if (key == "max_ms_per_coin") target = &cfg.disp.max_ms_per_coin;
-          else if (key == "hard_timeout_ms") target = &cfg.disp.hard_timeout_ms;
-          else handled = false;
-          if (target) {
-            int def = *target;
-            try { *target = std::stoi(value); }
-            catch (...) { *target = def; cfg.warnings.push_back(fullkey + " invalid, using default " + std::to_string(def)); }
-          }
-        } else if (section == "audit") {
-          handled = true;
-          if (key == "coin_mass_g") {
-            double def = cfg.audit.coin_mass_g;
-            try { cfg.audit.coin_mass_g = std::stod(value); }
-            catch (...) { cfg.audit.coin_mass_g = def; cfg.warnings.push_back(fullkey + " invalid, using default " + std::to_string(def)); }
-          } else if (key == "tolerance_per_coin_g") {
-            double def = cfg.audit.tolerance_per_coin_g;
-            try { cfg.audit.tolerance_per_coin_g = std::stod(value); }
-            catch (...) { cfg.audit.tolerance_per_coin_g = def; cfg.warnings.push_back(fullkey + " invalid, using default " + std::to_string(def)); }
-          } else if (key == "grams_per_raw") {
-            double def = cfg.audit.grams_per_raw;
-            try { cfg.audit.grams_per_raw = std::stod(value); }
-            catch (...) { cfg.audit.grams_per_raw = def; cfg.warnings.push_back(fullkey + " invalid, using default " + std::to_string(def)); }
-          } else if (key == "tare_raw") {
-            long def = cfg.audit.tare_raw;
-            try { cfg.audit.tare_raw = std::stol(value); }
-            catch (...) { cfg.audit.tare_raw = def; cfg.warnings.push_back(fullkey + " invalid, using default " + std::to_string(def)); }
-          } else if (key == "samples_pre") {
-            int def = cfg.audit.samples_pre;
-            try { cfg.audit.samples_pre = std::stoi(value); }
-            catch (...) { cfg.audit.samples_pre = def; cfg.warnings.push_back(fullkey + " invalid, using default " + std::to_string(def)); }
-          } else if (key == "samples_post") {
-            int def = cfg.audit.samples_post;
-            try { cfg.audit.samples_post = std::stoi(value); }
-            catch (...) { cfg.audit.samples_post = def; cfg.warnings.push_back(fullkey + " invalid, using default " + std::to_string(def)); }
-          } else if (key == "settle_ms") {
-            int def = cfg.audit.settle_ms;
-            try { cfg.audit.settle_ms = std::stoi(value); }
-            catch (...) { cfg.audit.settle_ms = def; cfg.warnings.push_back(fullkey + " invalid, using default " + std::to_string(def)); }
-          } else if (key == "stuck_epsilon_raw") {
-            int def = cfg.audit.stuck_epsilon_raw;
-            try { cfg.audit.stuck_epsilon_raw = std::stoi(value); }
-            catch (...) { cfg.audit.stuck_epsilon_raw = def; cfg.warnings.push_back(fullkey + " invalid, using default " + std::to_string(def)); }
-          } else {
-            handled = false;
-          }
-        } else if (section == "presentation") {
-          handled = true;
-          if (key == "present_ms") {
-            int def = cfg.pres.present_ms;
-            try { cfg.pres.present_ms = std::stoi(value); }
-            catch (...) { cfg.pres.present_ms = def; cfg.warnings.push_back(fullkey + " invalid, using default " + std::to_string(def)); }
-          } else {
-            handled = false;
-          }
-        } else if (section == "selftest") {
-          handled = true;
-          if (key == "enable_coin_test") {
-            bool def = cfg.st.enable_coin_test;
-            try { cfg.st.enable_coin_test = std::stoi(value) != 0; }
-            catch (...) { cfg.st.enable_coin_test = def; cfg.warnings.push_back(fullkey + " invalid, using default " + (def?"1":"0")); }
-          } else {
-            handled = false;
-          }
-        } else if (section == "aws") {
-          handled = true;
-          if (key == "enable") {
-            bool def = cfg.aws.enable;
-            try { cfg.aws.enable = std::stoi(value) != 0; }
-            catch (...) { cfg.aws.enable = def; cfg.warnings.push_back(fullkey + " invalid, using default " + (def?"1":"0")); }
-          } else if (key == "endpoint") {
-            cfg.aws.endpoint = value;
-          } else if (key == "thing_name") {
-            cfg.aws.thing_name = value;
-          } else if (key == "client_id") {
-            cfg.aws.client_id = value;
-          } else if (key == "root_ca") {
-            cfg.aws.root_ca = value;
-          } else if (key == "cert") {
-            cfg.aws.cert = value;
-          } else if (key == "key") {
-            cfg.aws.key = value;
-          } else if (key == "topic_prefix") {
-            cfg.aws.topic_prefix = value;
-          } else if (key == "qos") {
-            int def = cfg.aws.qos;
-            try { cfg.aws.qos = std::stoi(value); }
-            catch (...) { cfg.aws.qos = def; cfg.warnings.push_back(fullkey + " invalid, using default " + std::to_string(def)); }
-          } else if (key == "queue_dir") {
-            cfg.aws.queue_dir = value;
-          } else if (key == "max_queue_bytes") {
-            uint64_t def = cfg.aws.max_queue_bytes;
-            try { cfg.aws.max_queue_bytes = std::stoull(value); }
-            catch (...) { cfg.aws.max_queue_bytes = def; cfg.warnings.push_back(fullkey + " invalid, using default " + std::to_string(def)); }
-          } else if (key == "use_tls_identity") {
-            bool def = cfg.aws.use_tls_identity;
-            try { cfg.aws.use_tls_identity = std::stoi(value) != 0; }
-            catch (...) { cfg.aws.use_tls_identity = def; cfg.warnings.push_back(fullkey + " invalid, using default " + (def?"1":"0")); }
-          } else if (key == "rotation_check_minutes") {
-            int def = cfg.aws.rotation_check_minutes;
-            try { cfg.aws.rotation_check_minutes = std::stoi(value); }
-            catch (...) { cfg.aws.rotation_check_minutes = def; cfg.warnings.push_back(fullkey + " invalid, using default " + std::to_string(def)); }
-          } else {
-            handled = false;
-          }
-        } else if (section == "security") {
-          handled = true;
-          if (key == "enable_ro_root") {
-            bool def = cfg.security.enable_ro_root;
-            try { cfg.security.enable_ro_root = std::stoi(value) != 0; }
-            catch (...) { cfg.security.enable_ro_root = def; cfg.warnings.push_back(fullkey + " invalid, using default " + (def?"1":"0")); }
-          } else if (key == "ssh_keys_only") {
-            bool def = cfg.security.ssh_keys_only;
-            try { cfg.security.ssh_keys_only = std::stoi(value) != 0; }
-            catch (...) { cfg.security.ssh_keys_only = def; cfg.warnings.push_back(fullkey + " invalid, using default " + (def?"1":"0")); }
-          } else if (key == "firewall_enable") {
-            bool def = cfg.security.firewall_enable;
-            try { cfg.security.firewall_enable = std::stoi(value) != 0; }
-            catch (...) { cfg.security.firewall_enable = def; cfg.warnings.push_back(fullkey + " invalid, using default " + (def?"1":"0")); }
-          } else if (key == "allow_ssh_from") {
-            cfg.security.allow_ssh_from = value;
-          } else if (key == "auditd_enable") {
-            bool def = cfg.security.auditd_enable;
-            try { cfg.security.auditd_enable = std::stoi(value) != 0; }
-            catch (...) { cfg.security.auditd_enable = def; cfg.warnings.push_back(fullkey + " invalid, using default " + (def?"1":"0")); }
-          } else if (key == "service_user") {
-            cfg.security.service_user = value;
-          } else {
-            handled = false;
-          }
-        } else if (section == "identity") {
-          handled = true;
-          if (key == "use_tpm") {
-            bool def = cfg.identity.use_tpm;
-            try { cfg.identity.use_tpm = std::stoi(value) != 0; }
-            catch (...) { cfg.identity.use_tpm = def; cfg.warnings.push_back(fullkey + " invalid, using default " + (def?"1":"0")); }
-          } else if (key == "tpm_parent_handle") {
-            cfg.identity.tpm_parent_handle = value;
-          } else if (key == "ca_endpoint") {
-            cfg.identity.ca_endpoint = value;
-          } else if (key == "cert_dir") {
-            cfg.identity.cert_dir = value;
-          } else if (key == "device_id_prefix") {
-            cfg.identity.device_id_prefix = value;
-          } else {
-            handled = false;
-          }
-        } else if (section == "safety") {
-          handled = true;
-          int* target = nullptr;
-          if (key == "estop_pin") target = &cfg.safety.estop_pin;
-          else if (key == "lid_tamper_pin") target = &cfg.safety.lid_tamper_pin;
-          else if (key == "overcurrent_pin") target = &cfg.safety.overcurrent_pin;
-          else if (key == "debounce_ms") target = &cfg.safety.debounce_ms;
-          if (key == "active_high") {
-            bool def = cfg.safety.active_high;
-            try { cfg.safety.active_high = std::stoi(value) != 0; }
-            catch (...) { cfg.safety.active_high = def; cfg.warnings.push_back(fullkey + " invalid, using default " + (def?"1":"0")); }
-          } else if (target) {
-            int def = *target;
-            try { *target = std::stoi(value); }
-            catch (...) { *target = def; cfg.warnings.push_back(fullkey + " invalid, using default " + std::to_string(def)); }
-          } else {
-            handled = false;
-          }
-        } else if (section == "service") {
-          handled = true;
-          if (key == "enable") {
-            bool def = cfg.service.enable;
-            try { cfg.service.enable = std::stoi(value) != 0; }
-            catch (...) { cfg.service.enable = def; cfg.warnings.push_back(fullkey + " invalid, using default " + (def?"1":"0")); }
-          } else if (key == "pin_code") {
-            cfg.service.pin_code = value;
-          } else if (key == "jam_clear_shutter_mm") {
-            int def = cfg.service.jam_clear_shutter_mm;
-            try { cfg.service.jam_clear_shutter_mm = std::stoi(value); }
-            catch (...) { cfg.service.jam_clear_shutter_mm = def; cfg.warnings.push_back(fullkey + " invalid, using default " + std::to_string(def)); }
-          } else if (key == "jam_clear_cycles") {
-            int def = cfg.service.jam_clear_cycles;
-            try { cfg.service.jam_clear_cycles = std::stoi(value); }
-            catch (...) { cfg.service.jam_clear_cycles = def; cfg.warnings.push_back(fullkey + " invalid, using default " + std::to_string(def)); }
-          } else if (key == "hopper_nudge_ms") {
-            int def = cfg.service.hopper_nudge_ms;
-            try { cfg.service.hopper_nudge_ms = std::stoi(value); }
-            catch (...) { cfg.service.hopper_nudge_ms = def; cfg.warnings.push_back(fullkey + " invalid, using default " + std::to_string(def)); }
-          } else if (key == "hopper_max_retries") {
-            int def = cfg.service.hopper_max_retries;
-            try { cfg.service.hopper_max_retries = std::stoi(value); }
-            catch (...) { cfg.service.hopper_max_retries = def; cfg.warnings.push_back(fullkey + " invalid, using default " + std::to_string(def)); }
-          } else if (key == "audit_path") {
-            cfg.service.audit_path = value;
-          } else {
-            handled = false;
-          }
-        } else if (section == "pos") {
-          handled = true;
-          if (key == "enable_http") {
-            bool def = cfg.pos.enable_http;
-            try { cfg.pos.enable_http = std::stoi(value) != 0; }
-            catch (...) { cfg.pos.enable_http = def; cfg.warnings.push_back(fullkey + " invalid, using default " + (def?"1":"0")); }
-          } else if (key == "port") {
-            int def = cfg.pos.port;
-            try { cfg.pos.port = std::stoi(value); }
-            catch (...) { cfg.pos.port = def; cfg.warnings.push_back(fullkey + " invalid, using default " + std::to_string(def)); }
-          } else if (key == "key") {
-            cfg.pos.key = value;
-          } else if (key == "tls_cert") {
-            cfg.pos.tls_cert = value;
-          } else if (key == "tls_key") {
-            cfg.pos.tls_key = value;
-          } else {
-            handled = false;
-          }
-        } else if (section == "ota") {
-          handled = true;
-          if (key == "enable") {
-            bool def = cfg.ota.enable;
-            try { cfg.ota.enable = std::stoi(value) != 0; }
-            catch (...) { cfg.ota.enable = def; cfg.warnings.push_back(fullkey + " invalid, using default " + (def?"1":"0")); }
-          } else if (key == "backend") {
-            cfg.ota.backend = value;
-          } else if (key == "feed_url") {
-            cfg.ota.feed_url = value;
-          } else if (key == "channel") {
-            cfg.ota.channel = value;
-          } else if (key == "ring") {
-            cfg.ota.ring = value;
-          } else if (key == "poll_seconds") {
-            int def = cfg.ota.poll_seconds;
-            try { cfg.ota.poll_seconds = std::stoi(value); }
-            catch (...) { cfg.ota.poll_seconds = def; cfg.warnings.push_back(fullkey + " invalid, using default " + std::to_string(def)); }
-          } else if (key == "state_dir") {
-            cfg.ota.state_dir = value;
-          } else if (key == "key_pub") {
-            cfg.ota.key_pub = value;
-          } else if (key == "health_grace_seconds") {
-            int def = cfg.ota.health_grace_seconds;
-            try { cfg.ota.health_grace_seconds = std::stoi(value); }
-            catch (...) { cfg.ota.health_grace_seconds = def; cfg.warnings.push_back(fullkey + " invalid, using default " + std::to_string(def)); }
-          } else if (key == "require_signed") {
-            bool def = cfg.ota.require_signed;
-            try { cfg.ota.require_signed = std::stoi(value) != 0; }
-            catch (...) { cfg.ota.require_signed = def; cfg.warnings.push_back(fullkey + " invalid, using default " + (def?"1":"0")); }
-          } else {
-            handled = false;
-          }
-        } else if (section == "manufacturing") {
-          handled = true;
-          if (key == "enable_first_boot_eol") {
-            bool def = cfg.mfg.enable_first_boot_eol;
-            try { cfg.mfg.enable_first_boot_eol = std::stoi(value) != 0; }
-            catch(...) { cfg.mfg.enable_first_boot_eol = def; cfg.warnings.push_back(fullkey + " invalid, using default " + (def?"1":"0")); }
-          } else if (key == "label_printer_uri") {
-            cfg.mfg.label_printer_uri = value;
-          } else if (key == "label_template") {
-            cfg.mfg.label_template = value;
-          } else if (key == "company_name") {
-            cfg.mfg.company_name = value;
-          } else {
-            handled = false;
-          }
-        } else if (section == "eol") {
-          handled = true;
-          if (key == "weigh_tolerance_g") {
-            double def = cfg.eol.weigh_tolerance_g;
-            try { cfg.eol.weigh_tolerance_g = std::stod(value); }
-            catch(...) { cfg.eol.weigh_tolerance_g = def; cfg.warnings.push_back(fullkey + " invalid, using default "+std::to_string(def)); }
-          } else if (key == "coins_for_test") {
-            int def = cfg.eol.coins_for_test;
-            try { cfg.eol.coins_for_test = std::stoi(value); }
-            catch(...) { cfg.eol.coins_for_test = def; cfg.warnings.push_back(fullkey+" invalid, using default "+std::to_string(def)); }
-          } else if (key == "open_mm") {
-            int def = cfg.eol.open_mm;
-            try { cfg.eol.open_mm = std::stoi(value); }
-            catch(...) { cfg.eol.open_mm = def; cfg.warnings.push_back(fullkey+" invalid, using default "+std::to_string(def)); }
-          } else if (key == "present_ms") {
-            int def = cfg.eol.present_ms;
-            try { cfg.eol.present_ms = std::stoi(value); }
-            catch(...) { cfg.eol.present_ms = def; cfg.warnings.push_back(fullkey+" invalid, using default "+std::to_string(def)); }
-          } else if (key == "retries") {
-            int def = cfg.eol.retries;
-            try { cfg.eol.retries = std::stoi(value); }
-            catch(...) { cfg.eol.retries = def; cfg.warnings.push_back(fullkey+" invalid, using default "+std::to_string(def)); }
-          } else if (key == "min_success_txn_visible_seconds") {
-            int def = cfg.eol.min_success_txn_visible_seconds;
-            try { cfg.eol.min_success_txn_visible_seconds = std::stoi(value); }
-            catch(...) { cfg.eol.min_success_txn_visible_seconds = def; cfg.warnings.push_back(fullkey+" invalid, using default "+std::to_string(def)); }
-          } else if (key == "result_dir") {
-            cfg.eol.result_dir = value;
-          } else {
-            handled = false;
-          }
-        } else if (section == "burnin") {
-          handled = true;
-          if (key == "cycles") {
-            int def = cfg.burnin.cycles;
-            try { cfg.burnin.cycles = std::stoi(value); }
-            catch(...) { cfg.burnin.cycles = def; cfg.warnings.push_back(fullkey+" invalid, using default "+std::to_string(def)); }
-          } else if (key == "rest_ms") {
-            int def = cfg.burnin.rest_ms;
-            try { cfg.burnin.rest_ms = std::stoi(value); }
-            catch(...) { cfg.burnin.rest_ms = def; cfg.warnings.push_back(fullkey+" invalid, using default "+std::to_string(def)); }
-          } else if (key == "abort_on_fault") {
-            bool def = cfg.burnin.abort_on_fault;
-            try { cfg.burnin.abort_on_fault = std::stoi(value) != 0; }
-            catch(...) { cfg.burnin.abort_on_fault = def; cfg.warnings.push_back(fullkey+" invalid, using default "+(def?"1":"0")); }
-          } else if (key == "log_path") {
-            cfg.burnin.log_path = value;
-          } else {
-            handled = false;
-          }
-        } else if (section == "quant") {
-          handled = true;
-          if (key == "enable") {
-            bool def = cfg.quant.enable;
-            try { cfg.quant.enable = std::stoi(value) != 0; }
-            catch(...) { cfg.quant.enable = def; cfg.warnings.push_back(fullkey+" invalid, using default "+(def?"1":"0")); }
-          } else if (key == "endpoint") {
-            cfg.quant.endpoint = value;
-          } else if (key == "client_id") {
-            cfg.quant.client_id = value;
-          } else if (key == "hmac_key_hex") {
-            cfg.quant.hmac_key_hex = value;
-          } else if (key == "topic") {
-            cfg.quant.topic = value;
-          } else if (key == "queue_dir") {
-            cfg.quant.queue_dir = value;
-          } else if (key == "backoff_ms") {
-            cfg.quant.backoff_ms = value;
-          } else if (key == "heartbeat_seconds") {
-            int def = cfg.quant.heartbeat_seconds;
-            try { cfg.quant.heartbeat_seconds = std::stoi(value); }
-            catch(...) { cfg.quant.heartbeat_seconds = def; cfg.warnings.push_back(fullkey+" invalid, using default "+std::to_string(def)); }
-          } else if (key == "reserve_floor_cents") {
-            int def = cfg.quant.reserve_floor_cents;
-            try { cfg.quant.reserve_floor_cents = std::stoi(value); }
-            catch(...) { cfg.quant.reserve_floor_cents = def; cfg.warnings.push_back(fullkey+" invalid, using default "+std::to_string(def)); }
-          } else if (key == "max_daily_outflow_cents") {
-            int def = cfg.quant.max_daily_outflow_cents;
-            try { cfg.quant.max_daily_outflow_cents = std::stoi(value); }
-            catch(...) { cfg.quant.max_daily_outflow_cents = def; cfg.warnings.push_back(fullkey+" invalid, using default "+std::to_string(def)); }
-          } else if (key == "min_step_change_cents") {
-            int def = cfg.quant.min_step_change_cents;
-            try { cfg.quant.min_step_change_cents = std::stoi(value); }
-            catch(...) { cfg.quant.min_step_change_cents = def; cfg.warnings.push_back(fullkey+" invalid, using default "+std::to_string(def)); }
-          } else if (key == "max_update_rate_hz") {
-            int def = cfg.quant.max_update_rate_hz;
-            try { cfg.quant.max_update_rate_hz = std::stoi(value); }
-            catch(...) { cfg.quant.max_update_rate_hz = def; cfg.warnings.push_back(fullkey+" invalid, using default "+std::to_string(def)); }
-          } else if (key == "tolerance_cents") {
-            int def = cfg.quant.tolerance_cents;
-            try { cfg.quant.tolerance_cents = std::stoi(value); }
-            catch(...) { cfg.quant.tolerance_cents = def; cfg.warnings.push_back(fullkey+" invalid, using default "+std::to_string(def)); }
-          } else if (key == "client_public" || key == "client_secret" || key == "server_public") {
-            // accepted but not stored; avoid unknown warning
-          } else {
-            handled = false;
-          }
+        auto sit = section_parsers.find(section);
+        if (sit != section_parsers.end()) {
+          handled = sit->second(cfg, key, value, fullkey);
         }
       } catch (...) {
-        // Should not reach, but guard anyway
         cfg.warnings.push_back(fullkey + " invalid, using default");
+        handled = true;
       }
       if (!handled) {
         cfg.warnings.push_back(fullkey + " unknown, ignoring");

--- a/tests/config_defaults_test.cpp
+++ b/tests/config_defaults_test.cpp
@@ -45,3 +45,112 @@ TEST(Config, InvalidValueWarning) {
   unsetenv("REGISTER_MVP_CONFIG");
   std::remove(path.c_str());
 }
+
+TEST(Config, OverridesAllSections) {
+  std::string path = "test_overrides.ini";
+  {
+    std::ofstream f(path);
+    f << "[io.pins]\nstep=1\n";
+    f << "[mechanics]\nsteps_per_mm=200\n";
+    f << "[hopper]\npulses_per_coin=2\n";
+    f << "[dispense]\njam_ms=111\n";
+    f << "[audit]\ncoin_mass_g=1.23\n";
+    f << "[presentation]\npresent_ms=333\n";
+    f << "[selftest]\nenable_coin_test=0\n";
+    f << "[aws]\nenable=1\nendpoint=http://example\n";
+    f << "[security]\nenable_ro_root=1\n";
+    f << "[identity]\nuse_tpm=1\n";
+    f << "[safety]\nestop_pin=5\n";
+    f << "[service]\nenable=0\n";
+    f << "[pos]\nenable_http=0\n";
+    f << "[ota]\nenable=1\n";
+    f << "[manufacturing]\nenable_first_boot_eol=0\n";
+    f << "[eol]\nweigh_tolerance_g=0.5\n";
+    f << "[burnin]\ncycles=1000\n";
+    f << "[quant]\nenable=1\n";
+  }
+  setenv("REGISTER_MVP_CONFIG", path.c_str(), 1);
+  auto c = cfg::load();
+  EXPECT_EQ(c.pins.step, 1);
+  EXPECT_EQ(c.mech.steps_per_mm, 200);
+  EXPECT_EQ(c.hopper.pulses_per_coin, 2);
+  EXPECT_EQ(c.disp.jam_ms, 111);
+  EXPECT_DOUBLE_EQ(c.audit.coin_mass_g, 1.23);
+  EXPECT_EQ(c.pres.present_ms, 333);
+  EXPECT_FALSE(c.st.enable_coin_test);
+  EXPECT_TRUE(c.aws.enable);
+  EXPECT_EQ(c.aws.endpoint, "http://example");
+  EXPECT_TRUE(c.security.enable_ro_root);
+  EXPECT_TRUE(c.identity.use_tpm);
+  EXPECT_EQ(c.safety.estop_pin, 5);
+  EXPECT_FALSE(c.service.enable);
+  EXPECT_FALSE(c.pos.enable_http);
+  EXPECT_TRUE(c.ota.enable);
+  EXPECT_FALSE(c.mfg.enable_first_boot_eol);
+  EXPECT_DOUBLE_EQ(c.eol.weigh_tolerance_g, 0.5);
+  EXPECT_EQ(c.burnin.cycles, 1000);
+  EXPECT_TRUE(c.quant.enable);
+  unsetenv("REGISTER_MVP_CONFIG");
+  std::remove(path.c_str());
+}
+
+TEST(Config, InvalidValuesAllSections) {
+  std::string path = "test_invalid_all.ini";
+  {
+    std::ofstream f(path);
+    f << "[io.pins]\nstep=abc\n";
+    f << "[mechanics]\nsteps_per_mm=abc\n";
+    f << "[hopper]\npulses_per_coin=abc\n";
+    f << "[dispense]\njam_ms=abc\n";
+    f << "[audit]\ncoin_mass_g=abc\n";
+    f << "[presentation]\npresent_ms=abc\n";
+    f << "[selftest]\nenable_coin_test=abc\n";
+    f << "[aws]\nenable=abc\n";
+    f << "[security]\nenable_ro_root=abc\n";
+    f << "[identity]\nuse_tpm=abc\n";
+    f << "[safety]\nestop_pin=abc\n";
+    f << "[service]\nenable=abc\n";
+    f << "[pos]\nenable_http=abc\n";
+    f << "[ota]\nenable=abc\n";
+    f << "[manufacturing]\nenable_first_boot_eol=abc\n";
+    f << "[eol]\nweigh_tolerance_g=abc\n";
+    f << "[burnin]\ncycles=abc\n";
+    f << "[quant]\nenable=abc\n";
+  }
+  setenv("REGISTER_MVP_CONFIG", path.c_str(), 1);
+  auto c = cfg::load();
+  const auto& d = cfg::defaults();
+  EXPECT_EQ(c.pins.step, d.pins.step);
+  EXPECT_EQ(c.mech.steps_per_mm, d.mech.steps_per_mm);
+  EXPECT_EQ(c.hopper.pulses_per_coin, d.hopper.pulses_per_coin);
+  EXPECT_EQ(c.disp.jam_ms, d.disp.jam_ms);
+  EXPECT_DOUBLE_EQ(c.audit.coin_mass_g, d.audit.coin_mass_g);
+  EXPECT_EQ(c.pres.present_ms, d.pres.present_ms);
+  EXPECT_EQ(c.st.enable_coin_test, d.st.enable_coin_test);
+  EXPECT_EQ(c.aws.enable, d.aws.enable);
+  EXPECT_EQ(c.security.enable_ro_root, d.security.enable_ro_root);
+  EXPECT_EQ(c.identity.use_tpm, d.identity.use_tpm);
+  EXPECT_EQ(c.safety.estop_pin, d.safety.estop_pin);
+  EXPECT_EQ(c.service.enable, d.service.enable);
+  EXPECT_EQ(c.pos.enable_http, d.pos.enable_http);
+  EXPECT_EQ(c.ota.enable, d.ota.enable);
+  EXPECT_EQ(c.mfg.enable_first_boot_eol, d.mfg.enable_first_boot_eol);
+  EXPECT_DOUBLE_EQ(c.eol.weigh_tolerance_g, d.eol.weigh_tolerance_g);
+  EXPECT_EQ(c.burnin.cycles, d.burnin.cycles);
+  EXPECT_EQ(c.quant.enable, d.quant.enable);
+  std::vector<std::string> keys = {
+    "io.pins.step","mechanics.steps_per_mm","hopper.pulses_per_coin","dispense.jam_ms",
+    "audit.coin_mass_g","presentation.present_ms","selftest.enable_coin_test","aws.enable",
+    "security.enable_ro_root","identity.use_tpm","safety.estop_pin","service.enable",
+    "pos.enable_http","ota.enable","manufacturing.enable_first_boot_eol","eol.weigh_tolerance_g",
+    "burnin.cycles","quant.enable"};
+  for (const auto& k : keys) {
+    bool found = false;
+    for (const auto& w : c.warnings) {
+      if (w.find(k) != std::string::npos) { found = true; break; }
+    }
+    EXPECT_TRUE(found) << k;
+  }
+  unsetenv("REGISTER_MVP_CONFIG");
+  std::remove(path.c_str());
+}


### PR DESCRIPTION
### **User description**
## Summary
- Split monolithic `cfg::load` into small parse_* helpers and use a section/key lookup table
- Cover all configuration sections with new override and invalid value tests

## Testing
- `make test` *(fails: Unable to find executable: hal_mock_test_NOT_BUILT)*

------
https://chatgpt.com/codex/tasks/task_e_68a4cebde7a08333a652510a574feb1c


___

### **PR Type**
Enhancement


___

### **Description**
- Refactor monolithic config loader into modular section parsers

- Replace 400+ line if-else chain with lookup tables

- Add comprehensive test coverage for all configuration sections

- Improve error handling with type-safe setter functions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Monolithic cfg::load()"] --> B["Section Parser Map"]
  B --> C["Type-safe Setters"]
  C --> D["Comprehensive Tests"]
  A --> E["400+ line if-else chain"]
  E --> F["Modular parse_* functions"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.cpp</strong><dd><code>Refactor monolithic config parser into modular components</code></dd></summary>
<hr>

src/config/config.cpp

<ul><li>Replace massive if-else chain with section parser lookup table<br> <li> Add type-safe setter functions for int, long, double, uint64, bool<br> <li> Create 18 modular parse_* functions for each config section<br> <li> Simplify main parsing loop to use function pointers</ul>


</details>


  </td>
  <td><a href="https://github.com/zveasy/DrawerBackend/pull/31/files#diff-106038a764eaa8f4a2b7654b748f97651804c099f848ec9f140d1580aa095cd4">+331/-404</a></td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config_defaults_test.cpp</strong><dd><code>Add comprehensive config section test coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/config_defaults_test.cpp

<ul><li>Add comprehensive test covering all 18 configuration sections<br> <li> Test invalid value handling with fallback to defaults<br> <li> Verify warning generation for malformed configuration values</ul>


</details>


  </td>
  <td><a href="https://github.com/zveasy/DrawerBackend/pull/31/files#diff-863fea49c5f1a5936837976e3d9ce83313e1c4778e5aba55200ae7fcdb99db52">+109/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

