### PR TITLE
Add architecture documentation and index links

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ cmake --build build-gpio -j
 Minimal C++17 + CMake project demonstrating a stepper-based shutter,
 parallel hopper, and HX711 scale with a mockable GPIO HAL.
 
+## Architecture
+
+See [docs/architecture.md](docs/architecture.md) for an overview of the HAL, drivers, application logic, HTTP server, and test harness.
+
 ## Native build
 
 ```bash

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,45 @@
+# Architecture Overview
+
+This document outlines how the Register MVP components interact: the hardware abstraction layer (HAL), device drivers, application logic, HTTP server, and deterministic test harness.
+
+## Component Relationships
+
+```mermaid
+flowchart TD
+    HAL[Hardware Abstraction Layer] --> Drivers
+    Drivers --> App[Application Logic]
+    App --> Server[HTTP Server]
+    Test[Test Harness] --> HAL
+    Client --> Server
+```
+
+- **HAL** wraps low level GPIO access and provides a consistent interface for real hardware and simulations.
+- **Drivers** implement devices such as the shutter, hopper, and scale on top of the HAL.
+- **Application logic** coordinates drivers to perform transactions and other high level tasks.
+- **Server** exposes the application logic over an HTTP API.
+- **Test harness** exercises the application through the HAL with deterministic inputs to validate behavior.
+
+## Transaction Processing
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant S as Server
+    participant A as App
+    participant D as Drivers
+    participant H as HAL
+    participant HW as Hardware
+
+    C->>S: HTTP request
+    S->>A: Route and validate
+    A->>D: Command execution
+    D->>H: GPIO operations
+    H->>HW: Signals
+    HW-->>H: Sensor data
+    H-->>D: Driver result
+    D-->>A: Outcome
+    A-->>S: Response payload
+    S-->>C: HTTP 200
+```
+
+The sequence above shows a typical transaction. Client requests are handled by the server, routed through application logic to the drivers and HAL, and results propagate back to the client.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,3 +6,4 @@ device and are reachable via the `/help` endpoint.
 
 Use the navigation to access specific topics.
 
+- [Architecture Overview](architecture.md)


### PR DESCRIPTION
## Summary
- Document overall HAL, driver, app, server, and test harness relationships
- Link architecture guide from README and docs index

## Testing
- `pre-commit run --files README.md docs/index.md docs/architecture.md`
- `ctest --test-dir build` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e16bf5c88333894615c25a277cab