### PR TITLE
Add static analysis tooling and workflow

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,36 @@
+name: Static Analysis
+
+on:
+  pull_request:
+
+jobs:
+  static-analysis:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cppcheck clang-tools
+          pip install licensecheck pip-audit
+      - name: Run cppcheck
+        run: |
+          cppcheck --std=c++17 --enable=all --inconclusive --xml --xml-version=2 src 2> cppcheck.xml
+      - name: Run clang static analyzer
+        run: |
+          scan-build --status-bugs -o clang-analyzer-report make
+      - name: Run pip-audit
+        run: |
+          if [ -f requirements.txt ]; then pip-audit -r requirements.txt -f json -o pip-audit.json; else pip-audit -f json -o pip-audit.json; fi
+      - name: Run licensecheck
+        run: |
+          licensecheck > license-report.txt
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: static-analysis-reports
+          path: |
+            cppcheck.xml
+            clang-analyzer-report
+            license-report.txt
+            pip-audit.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,23 @@ repos:
         language: system
         files: '\.(c|cc|cpp|cxx|h|hh|hpp)$'
         args: ['--config-file=.clang-tidy', '--extra-arg=-Isrc', '--extra-arg=-I.', '--extra-arg=-I/usr/src/googletest/googletest/include']
+      - id: cppcheck
+        name: cppcheck
+        entry: cppcheck --std=c++17 --enable=all --error-exitcode=1
+        language: system
+        files: '\.(c|cc|cpp|cxx|h|hh|hpp)$'
+      - id: clang-analyzer
+        name: clang-analyzer
+        entry: clang++-18 --analyze -std=c++17 -I. -Isrc
+        language: system
+        files: '\.(c|cc|cpp|cxx|h|hh|hpp)$'
+      - id: pip-audit
+        name: pip-audit
+        entry: bash -c 'if [ -f requirements.txt ]; then pip-audit -r requirements.txt; else echo "no requirements.txt"; fi'
+        language: system
+        pass_filenames: false
+      - id: licensecheck
+        name: licensecheck
+        entry: licensecheck
+        language: system
+        pass_filenames: false


### PR DESCRIPTION
## Summary
- add cppcheck, clang-analyzer, pip-audit and licensecheck to pre-commit config
- introduce static-analysis workflow to run analyzers on pull requests and upload reports

## Testing
- `pre-commit run --files .pre-commit-config.yaml .github/workflows/static-analysis.yml`


------
https://chatgpt.com/codex/tasks/task_e_68a4e3f77fe083338ef35c1b91094c84