### PR TITLE
Add static analysis hooks and workflow

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,42 @@
+name: static-analysis
+
+on:
+  pull_request:
+
+jobs:
+  static-analysis:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cppcheck clang-tidy
+          pip install pip-licenses pip-audit pre-commit
+      - name: Run pre-commit
+        run: pre-commit run --all-files
+      - name: Run cppcheck
+        run: |
+          cppcheck --enable=all --inconclusive --error-exitcode=1 --xml --xml-version=2 . 2> cppcheck.xml
+      - name: Run clang analyzer
+        run: |
+          clang-tidy $(git ls-files '*.c' '*.cc' '*.cpp' '*.cxx' '*.h' '*.hh' '*.hpp') \
+            --checks='clang-analyzer-*' --warnings-as-errors='*' \
+            --extra-arg=-Isrc --extra-arg=-I. --extra-arg=-I/usr/src/googletest/googletest/include \
+            2> clang-analyzer.txt
+      - name: License and dependency scan
+        run: |
+          pip-licenses --format=json --output-file=licenses.json --fail-on=AGPL-3.0
+          pip-audit -f json -o pip-audit.json
+      - name: Upload analysis reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: static-analysis-reports
+          path: |
+            cppcheck.xml
+            clang-analyzer.txt
+            licenses.json
+            pip-audit.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,10 +5,33 @@ repos:
         name: clang-format
         entry: clang-format -i
         language: system
-        files: '\.(c|cc|cpp|cxx|h|hh|hpp)$'
+        files: '\\.(c|cc|cpp|cxx|h|hh|hpp)$'
       - id: clang-tidy
         name: clang-tidy
         entry: clang-tidy
         language: system
-        files: '\.(c|cc|cpp|cxx|h|hh|hpp)$'
+        files: '\\.(c|cc|cpp|cxx|h|hh|hpp)$'
         args: ['--config-file=.clang-tidy', '--extra-arg=-Isrc', '--extra-arg=-I.', '--extra-arg=-I/usr/src/googletest/googletest/include']
+      - id: clang-analyzer
+        name: clang-analyzer
+        entry: clang-tidy
+        language: system
+        files: '\\.(c|cc|cpp|cxx|h|hh|hpp)$'
+        args: ['--checks=clang-analyzer-*', '--warnings-as-errors=*', '--extra-arg=-Isrc', '--extra-arg=-I.', '--extra-arg=-I/usr/src/googletest/googletest/include']
+      - id: pip-licenses
+        name: pip-licenses
+        entry: pip-licenses
+        language: system
+        pass_filenames: false
+        args: ['--fail-on=AGPL-3.0']
+  - repo: https://github.com/pre-commit/mirrors-cppcheck
+    rev: v2.12.0
+    hooks:
+      - id: cppcheck
+        args: ['--enable=all', '--inconclusive', '--error-exitcode=1']
+  - repo: https://github.com/pypa/pip-audit
+    rev: v2.9.0
+    hooks:
+      - id: pip-audit
+        args: ['--progress-spinner', 'off']
+        pass_filenames: false


### PR DESCRIPTION
## Summary
- extend pre-commit with cppcheck, clang analyzer, pip-licenses, and pip-audit hooks
- add static analysis GitHub Action running linters and scanners and uploading artifacts

## Testing
- `pre-commit run --files .pre-commit-config.yaml .github/workflows/static-analysis.yml` *(fails: requires GitHub auth for hook repos)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e3f7e1008333975362fda4d45469