### PR TITLE
Add release workflow and embed version info

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag (e.g., v1.2.3)'
+        required: true
+      changelog:
+        description: 'Release notes'
+        required: false
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+      - name: Tag release
+        run: |
+          git tag ${{ inputs.version }}
+          git push origin ${{ inputs.version }}
+      - name: Build
+        run: |
+          cmake -S . -B build -DAPP_VERSION=${{ inputs.version }}
+          cmake --build build --target register_mvp --config Release
+      - name: Package artifact
+        run: |
+          tar -czf register_mvp-${{ inputs.version }}.tar.gz -C build register_mvp
+      - name: Publish release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ inputs.version }}
+          name: ${{ inputs.version }}
+          body: ${{ inputs.changelog }}
+          files: register_mvp-${{ inputs.version }}.tar.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] - 2024-07-17
+### Added
+- Initial release.
+

--- a/docs/Release.md
+++ b/docs/Release.md
@@ -1,0 +1,18 @@
+# Release Process
+
+This project uses [Semantic Versioning](https://semver.org/).
+Follow these steps to create a new release:
+
+1. Ensure all changes for the release are merged into `main`.
+2. Update `CHANGELOG.md` with the new version and date.
+3. Bump the version in `CMakeLists.txt` if needed.
+4. Commit and push the changes.
+5. Run the **Release** workflow from the Actions tab and provide the version (e.g. `v1.2.3`).
+   The workflow will tag the commit, build the binaries, and publish a GitHub release.
+
+## Release criteria
+
+- All tests and linters pass.
+- `CHANGELOG.md` accurately reflects user-facing changes.
+- Version numbers follow `MAJOR.MINOR.PATCH` format.
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,6 +29,7 @@
 #include "obs/metrics.hpp"
 #include "compliance/compliance_mode.hpp"
 #include "util/cli_options.hpp"
+#include "util/version.hpp"
 
 #include <cstdlib>
 #include <iostream>
@@ -221,7 +222,8 @@ int main(int argc, char** argv) {
     cfg::Config cfg = lr.config;
     obs::M().gauge("register_device_up", "Device up").set(1);
     obs::M()
-        .gauge("register_build_info", "Build info", {{"version", "1.0.0"}, {"git", "unknown"}})
+        .gauge("register_build_info", "Build info",
+               {{"version", appver::version()}, {"git", appver::git()}})
         .set(1);
     eventlog::Logger elog(cfg.service.audit_path);
     safety::FaultManager faults(cfg.safety, &elog);


### PR DESCRIPTION
## Summary
- add semantic versioning changelog
- document release process for maintainers
- embed build version info and add release workflow

## Testing
- `pre-commit run --files CHANGELOG.md src/main.cpp .github/workflows/release.yml docs/Release.md` *(fails: 'httplib.h' file not found; licensecheck: No paths provided)*
- `make test` *(fails: build directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a5dc8eac2c83338357990a60aed234