### PR TITLE
Protect metrics endpoints

### DIFF
--- a/docs/SecurityHardening.md
+++ b/docs/SecurityHardening.md
@@ -7,3 +7,4 @@ This document outlines the baseline hardening applied to the device.
 * SSH key-only authentication
 * nftables firewall deny-by-default
 * auditd rules for key files
+* Metrics endpoints require authentication

--- a/tests/http_handlers_test.cpp
+++ b/tests/http_handlers_test.cpp
@@ -23,35 +23,46 @@ class HttpHandlers : public ::testing::TestWithParam<bool> {};
 TEST_P(HttpHandlers, BasicFlow) {
   bool tls = GetParam();
   std::filesystem::remove_all("data");
-  FakeShutter sh; FakeDispenser disp; TxnConfig cfg; TxnEngine eng(sh, disp, cfg);
-  std::string cert, key; if (tls) write_test_cert(std::filesystem::temp_directory_path()/"httptest", cert, key);
-  HttpServer srv(eng, sh, disp); ASSERT_TRUE(tls ? srv.start("127.0.0.1", 0, cert, key) : srv.start("127.0.0.1", 0));
+  FakeShutter sh;
+  FakeDispenser disp;
+  TxnConfig cfg;
+  TxnEngine eng(sh, disp, cfg);
+  std::string cert, key;
+  if (tls) write_test_cert(std::filesystem::temp_directory_path() / "httptest", cert, key);
+  HttpServer srv(eng, sh, disp);
+  ASSERT_TRUE(tls ? srv.start("127.0.0.1", 0, cert, key) : srv.start("127.0.0.1", 0));
   if (tls) {
     httplib::SSLClient cli("127.0.0.1", srv.port());
     cli.enable_server_certificate_verification(false);
     auto res = cli.Post("/txn", "{\"price\":735,\"deposit\":1000}", "application/json");
-    ASSERT_TRUE(res); EXPECT_EQ(200, res->status);
+    ASSERT_TRUE(res);
+    EXPECT_EQ(200, res->status);
     EXPECT_NE(std::string::npos, res->body.find("\"quarters\":10"));
     EXPECT_NE(std::string::npos, res->body.find("\"status\":\"OK\""));
     auto res2 = cli.Get("/status");
-    ASSERT_TRUE(res2); EXPECT_EQ(200, res2->status);
+    ASSERT_TRUE(res2);
+    EXPECT_EQ(200, res2->status);
     EXPECT_NE(std::string::npos, res2->body.find("\"in_progress\":false"));
     EXPECT_NE(std::string::npos, res2->body.find("\"change\":265"));
     auto res3 = cli.Post("/command", "{\"dispense\":2}", "application/json");
-    ASSERT_TRUE(res3); EXPECT_EQ(200, res3->status);
+    ASSERT_TRUE(res3);
+    EXPECT_EQ(200, res3->status);
     EXPECT_NE(std::string::npos, res3->body.find("\"ok\":true"));
   } else {
     httplib::Client cli("127.0.0.1", srv.port());
     auto res = cli.Post("/txn", "{\"price\":735,\"deposit\":1000}", "application/json");
-    ASSERT_TRUE(res); EXPECT_EQ(200, res->status);
+    ASSERT_TRUE(res);
+    EXPECT_EQ(200, res->status);
     EXPECT_NE(std::string::npos, res->body.find("\"quarters\":10"));
     EXPECT_NE(std::string::npos, res->body.find("\"status\":\"OK\""));
     auto res2 = cli.Get("/status");
-    ASSERT_TRUE(res2); EXPECT_EQ(200, res2->status);
+    ASSERT_TRUE(res2);
+    EXPECT_EQ(200, res2->status);
     EXPECT_NE(std::string::npos, res2->body.find("\"in_progress\":false"));
     EXPECT_NE(std::string::npos, res2->body.find("\"change\":265"));
     auto res3 = cli.Post("/command", "{\"dispense\":2}", "application/json");
-    ASSERT_TRUE(res3); EXPECT_EQ(200, res3->status);
+    ASSERT_TRUE(res3);
+    EXPECT_EQ(200, res3->status);
     EXPECT_NE(std::string::npos, res3->body.find("\"ok\":true"));
   }
 
@@ -61,28 +72,72 @@ TEST_P(HttpHandlers, BasicFlow) {
 TEST_P(HttpHandlers, MalformedJson) {
   bool tls = GetParam();
   std::filesystem::remove_all("data");
-  FakeShutter sh; FakeDispenser disp; TxnConfig cfg; TxnEngine eng(sh, disp, cfg);
-  std::string cert, key; if (tls) write_test_cert(std::filesystem::temp_directory_path()/"httptest2", cert, key);
-  HttpServer srv(eng, sh, disp); ASSERT_TRUE(tls ? srv.start("127.0.0.1", 0, cert, key) : srv.start("127.0.0.1", 0));
+  FakeShutter sh;
+  FakeDispenser disp;
+  TxnConfig cfg;
+  TxnEngine eng(sh, disp, cfg);
+  std::string cert, key;
+  if (tls) write_test_cert(std::filesystem::temp_directory_path() / "httptest2", cert, key);
+  HttpServer srv(eng, sh, disp);
+  ASSERT_TRUE(tls ? srv.start("127.0.0.1", 0, cert, key) : srv.start("127.0.0.1", 0));
   if (tls) {
     httplib::SSLClient cli("127.0.0.1", srv.port());
     cli.enable_server_certificate_verification(false);
     auto bad_txn = cli.Post("/txn", "not json", "application/json");
-    ASSERT_TRUE(bad_txn); EXPECT_EQ(400, bad_txn->status);
+    ASSERT_TRUE(bad_txn);
+    EXPECT_EQ(400, bad_txn->status);
     auto bad_cmd = cli.Post("/command", "{\"open\":\"bad\"}", "application/json");
-    ASSERT_TRUE(bad_cmd); EXPECT_EQ(400, bad_cmd->status);
+    ASSERT_TRUE(bad_cmd);
+    EXPECT_EQ(400, bad_cmd->status);
     auto bad_cmd2 = cli.Post("/command", "not json", "application/json");
-    ASSERT_TRUE(bad_cmd2); EXPECT_EQ(400, bad_cmd2->status);
+    ASSERT_TRUE(bad_cmd2);
+    EXPECT_EQ(400, bad_cmd2->status);
   } else {
     httplib::Client cli("127.0.0.1", srv.port());
     auto bad_txn = cli.Post("/txn", "not json", "application/json");
-    ASSERT_TRUE(bad_txn); EXPECT_EQ(400, bad_txn->status);
+    ASSERT_TRUE(bad_txn);
+    EXPECT_EQ(400, bad_txn->status);
     auto bad_cmd = cli.Post("/command", "{\"open\":\"bad\"}", "application/json");
-    ASSERT_TRUE(bad_cmd); EXPECT_EQ(400, bad_cmd->status);
+    ASSERT_TRUE(bad_cmd);
+    EXPECT_EQ(400, bad_cmd->status);
     auto bad_cmd2 = cli.Post("/command", "not json", "application/json");
-    ASSERT_TRUE(bad_cmd2); EXPECT_EQ(400, bad_cmd2->status);
+    ASSERT_TRUE(bad_cmd2);
+    EXPECT_EQ(400, bad_cmd2->status);
   }
 
+  srv.stop();
+}
+
+TEST_P(HttpHandlers, MetricsRequireAuth) {
+  bool tls = GetParam();
+  std::filesystem::remove_all("data");
+  FakeShutter sh;
+  FakeDispenser disp;
+  TxnConfig cfg;
+  TxnEngine eng(sh, disp, cfg);
+  std::string cert, key;
+  if (tls) write_test_cert(std::filesystem::temp_directory_path() / "httptest3", cert, key);
+  HttpServer srv(eng, sh, disp);
+  ASSERT_TRUE(tls ? srv.start("127.0.0.1", 0, cert, key, "tok")
+                  : srv.start("127.0.0.1", 0, "", "", "tok"));
+  if (tls) {
+    httplib::SSLClient cli("127.0.0.1", srv.port());
+    cli.enable_server_certificate_verification(false);
+    auto res = cli.Get("/metrics");
+    ASSERT_TRUE(res);
+    EXPECT_EQ(401, res->status);
+    auto resj = cli.Get("/metrics.json");
+    ASSERT_TRUE(resj);
+    EXPECT_EQ(401, resj->status);
+  } else {
+    httplib::Client cli("127.0.0.1", srv.port());
+    auto res = cli.Get("/metrics");
+    ASSERT_TRUE(res);
+    EXPECT_EQ(401, res->status);
+    auto resj = cli.Get("/metrics.json");
+    ASSERT_TRUE(resj);
+    EXPECT_EQ(401, resj->status);
+  }
   srv.stop();
 }
 


### PR DESCRIPTION
### **User description**
## Summary
- secure /metrics and /metrics.json with same auth check as other routes
- document requirement to protect metrics endpoints
- test 401 response for unauthenticated metrics requests

## Testing
- `pre-commit run --files src/server/http_server.cpp tests/http_handlers_test.cpp docs/SecurityHardening.md` *(fails: licensecheck: No paths provided)*
- `ctest --test-dir build -R HttpHandlers --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68a612c6d8388333828bb1e20df33a5f


___

### **PR Type**
Enhancement


___

### **Description**
- Secure `/metrics` and `/metrics.json` endpoints with authentication

- Add test coverage for unauthorized metrics access

- Document metrics endpoint security requirement

- Refactor authentication logic for code reuse


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["HTTP Request"] --> B["Pre-routing Handler"]
  B --> C{Auth Required?}
  C -->|Yes| D{Valid Token?}
  C -->|No| E["Allow Access"]
  D -->|Yes| E
  D -->|No| F["Return 401"]
  E --> G["Metrics Endpoint"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>http_server.cpp</strong><dd><code>Secure metrics endpoints with authentication</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/http_server.cpp

<ul><li>Extract authentication logic to reusable variables<br> <li> Add authentication checks to <code>/metrics</code> and <code>/metrics.json</code> endpoints<br> <li> Return 401 status for unauthorized metrics requests<br> <li> Apply code formatting improvements</ul>


</details>


  </td>
  <td><a href="https://github.com/zveasy/DrawerBackend/pull/40/files#diff-a94706c414f3dd1328e732a780f252700b09b20e18d7fcd79a294447e9e29ae9">+70/-40</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>http_handlers_test.cpp</strong><dd><code>Add metrics authentication tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/http_handlers_test.cpp

<ul><li>Add new test <code>MetricsRequireAuth</code> for unauthorized access<br> <li> Test 401 response for both <code>/metrics</code> and <code>/metrics.json</code><br> <li> Apply code formatting improvements to existing tests</ul>


</details>


  </td>
  <td><a href="https://github.com/zveasy/DrawerBackend/pull/40/files#diff-f4b8518d824430e621d1db3c23cb6d960735a1b38b883d3f12e120854de32e2e">+73/-18</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SecurityHardening.md</strong><dd><code>Document metrics security requirement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/SecurityHardening.md

- Document requirement for metrics endpoint authentication


</details>


  </td>
  <td><a href="https://github.com/zveasy/DrawerBackend/pull/40/files#diff-13ed946f8b73cfdb14ec378d793391882dec89fe5ab189e4f6e52f216d58f729">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

