### PR TITLE
Add hardening verification script and CI step

### DIFF
--- a/.github/workflows/compose-ci.yml
+++ b/.github/workflows/compose-ci.yml
@@ -17,6 +17,18 @@ permissions:
   security-events: write
 
 jobs:
+  hardening-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Apply hardening
+        run: scripts/hardening/apply_hardening.sh
+
+      - name: Verify hardening
+        run: scripts/hardening/verify_hardening.sh
+
   unit-tests:
     timeout-minutes: 20
     runs-on: ubuntu-latest

--- a/docs/HardeningChecklist.md
+++ b/docs/HardeningChecklist.md
@@ -4,3 +4,5 @@
 - [ ] SSH disables passwords
 - [ ] nftables default drop
 - [ ] auditd logging enabled
+
+After applying hardening, run `scripts/hardening/verify_hardening.sh` to validate these settings.

--- a/scripts/hardening/verify_hardening.sh
+++ b/scripts/hardening/verify_hardening.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# verify systemd unit runs as registermvp user
+if ! systemctl show register-mvp.service -p User --value 2>/dev/null | grep -qx 'registermvp'; then
+  echo "register-mvp service is not configured to run as registermvp user" >&2
+  exit 1
+fi
+
+# verify SSH password logins are disabled
+if ! sshd -T 2>/dev/null | grep -iq '^passwordauthentication no'; then
+  echo "SSH password authentication is not disabled" >&2
+  exit 1
+fi
+
+# verify nftables default policy drop
+if ! nft list ruleset 2>/dev/null | grep -q 'policy drop'; then
+  echo "nftables default policy is not set to drop" >&2
+  exit 1
+fi
+
+# verify auditd rule file present
+if [ ! -f /etc/audit/rules.d/register-mvp.rules ]; then
+  echo "auditd rule file /etc/audit/rules.d/register-mvp.rules is missing" >&2
+  exit 1
+fi
+
+echo "Hardening verification passed." 


### PR DESCRIPTION
## Summary
- add verify_hardening.sh script to confirm systemd user, SSH auth, nftables policy, and auditd rules
- run hardening apply+verify scripts in compose CI workflow
- document verification command in HardeningChecklist

## Testing
- `SKIP=licensecheck pre-commit run --files scripts/hardening/verify_hardening.sh .github/workflows/compose-ci.yml docs/HardeningChecklist.md`
- `licensecheck docs/HardeningChecklist.md scripts/hardening/verify_hardening.sh .github/workflows/compose-ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_68a64752395883338038848011466dda